### PR TITLE
[RFR] [ClassContent] #63 + add verbose filter to getAction() and getCollectionAction() of ClassContentController

### DIFF
--- a/ClassContent/AClassContent.php
+++ b/ClassContent/AClassContent.php
@@ -1071,21 +1071,25 @@ abstract class AClassContent extends AContent
     /**
      * {@inheritdoc}
      */
-    public function jsonSerialize()
+    public function jsonSerialize($verbose = true)
     {
-        $datas = array(
+        $data = array(
             'properties' => $this->getProperty(),
             'main_node'  => null === $this->getMainNode() ? null : $this->getMainNode()->getUid(),
             'draft_uid'  => null !== $this->getDraft() ? $this->getDraft()->getUid() : null,
             'image'      => $this->getImageName(),
         );
 
-        $datas = array_merge(parent::jsonSerialize(), $datas);
+        $data = array_merge(parent::jsonSerialize($verbose), $data);
 
-        if (null === $datas['label']) {
-            $datas['label'] = $this->getProperty('name');
+        if (null === $data['label']) {
+            $data['label'] = $this->getProperty('name');
         }
 
-        return $datas;
+        if (false === $verbose) {
+            unset($data['properties']);
+        }
+
+        return $data;
     }
 }

--- a/ClassContent/AClassContent.php
+++ b/ClassContent/AClassContent.php
@@ -23,11 +23,10 @@
 
 namespace BackBee\ClassContent;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Symfony\Component\Security\Core\Util\ClassUtils;
-
 use BackBee\ClassContent\Exception\ClassContentException;
 use BackBee\NestedNode\Page;
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\Security\Core\Util\ClassUtils;
 
 /**
  * Abstract class for content object in BackBee
@@ -1071,24 +1070,28 @@ abstract class AClassContent extends AContent
     /**
      * {@inheritdoc}
      */
-    public function jsonSerialize($verbose = true)
+    public function jsonSerialize($format = self::JSON_DEFAULT_FORMAT)
     {
-        $data = array(
-            'properties' => $this->getProperty(),
-            'main_node'  => null === $this->getMainNode() ? null : $this->getMainNode()->getUid(),
-            'draft_uid'  => null !== $this->getDraft() ? $this->getDraft()->getUid() : null,
-            'image'      => $this->getImageName(),
-        );
+        $data = parent::jsonSerialize($format);
 
-        $data = array_merge(parent::jsonSerialize($verbose), $data);
-
-        if (null === $data['label']) {
+        if (!isset($data['label'])) {
             $data['label'] = $this->getProperty('name');
         }
 
-        if (false === $verbose) {
-            unset($data['properties']);
+        if (self::JSON_CONCISE_FORMAT === $format) {
+            return $data;
         }
+
+        if (self::JSON_INFO_FORMAT === $format) {
+            unset($data['label']);
+
+            return $data;
+        }
+
+        $data = array_merge([
+            'properties' => $this->getProperty(),
+            'image'      => $this->getImageName(),
+        ], $data);
 
         return $data;
     }

--- a/ClassContent/AContent.php
+++ b/ClassContent/AContent.php
@@ -1016,9 +1016,9 @@ abstract class AContent implements IObjectIdentifiable, IRenderable, \JsonSerial
     /**
      * {@inheritdoc}
      */
-    public function jsonSerialize()
+    public function jsonSerialize($verbose = true)
     {
-        $datas = array(
+        $data = array(
             'uid'        => $this->_uid,
             'label'      => $this->_label,
             'type'       => str_replace(
@@ -1045,15 +1045,19 @@ abstract class AContent implements IObjectIdentifiable, IRenderable, \JsonSerial
             'maxentry'   => $this->getMaxEntry(),
         );
 
-        $datas['elements'] = array();
+        $data['elements'] = array();
         foreach ($this->getData() as $name => $content) {
             if ($content instanceof AContent) {
-                $datas['elements'][$name] = $content->jsonSerialize();
+                $data['elements'][$name] = $content->jsonSerialize($verbose);
             } elseif (is_scalar($content)) {
-                $datas['elements'][$name] = $content;
+                $data['elements'][$name] = $content;
             }
         }
 
-        return $datas;
+        if (false === $verbose) {
+            unset($data['accept'], $data['minentry'], $data['maxentry']);
+        }
+
+        return $data;
     }
 }

--- a/ClassContent/Category.php
+++ b/ClassContent/Category.php
@@ -81,7 +81,7 @@ class Category implements \JsonSerializable
         $block->label = $content->getProperty('name');
         $block->description = $content->getProperty('description');
         $block->type = str_replace(
-            array('BackBee\ClassContent\\', NAMESPACE_SEPARATOR),
+            array(AContent::CLASSCONTENT_BASE_NAMESPACE, NAMESPACE_SEPARATOR),
             array('', '/'),
             get_class($content)
         );

--- a/ClassContent/ContentSet.php
+++ b/ClassContent/ContentSet.php
@@ -521,6 +521,28 @@ class ContentSet extends AClassContent implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
+    public function jsonSerialize($format = self::JSON_DEFAULT_FORMAT)
+    {
+        $data = parent::jsonSerialize($format);
+
+        if (isset($data['elements'])) {
+            $elements = [];
+            foreach ($data['elements'] as $element) {
+                $elements[] = [
+                    'uid' => $element['uid'],
+                    'type' => $element['type'],
+                ];
+            }
+
+            $data['elements'] = $elements;
+        }
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function _initData()
     {
         if (null === $this->getProperty('auto_hydrate')) {

--- a/Config/route.yml
+++ b/Config/route.yml
@@ -302,24 +302,6 @@ bb.rest.classcontent.category.get_collection:
     requirements:
         _method: GET
 
-bb.rest.classcontent.definition.get:
-    pattern: /rest/{version}/classcontent/definition/{type}
-    defaults:
-        _action: getDefinitionAction
-        _controller: BackBee\Rest\Controller\ClassContentController
-    requirements:
-        type: "[a-zA-Z\/]+"
-        _method: GET
-
-bb.rest.classcontent.definition.get_collection:
-    pattern: /rest/{version}/classcontent/definition
-    defaults:
-        _action: getDefinitionCollectionAction
-        _controller: BackBee\Rest\Controller\ClassContentController
-    requirements:
-        type: "[a-zA-Z\/]+"
-        _method: GET
-
 bb.rest.classcontent.get:
     pattern: /rest/{version}/classcontent/{type}/{uid}
     defaults:
@@ -330,19 +312,19 @@ bb.rest.classcontent.get:
         type: .+
         _method: GET
 
-bb.rest.classcontent.get_collection:
+bb.rest.classcontent.get_collection_by_type:
     pattern: /rest/{version}/classcontent/{type}
     defaults:
-        _action: getCollectionAction
+        _action: getCollectionByTypeAction
         _controller: BackBee\Rest\Controller\ClassContentController
     requirements:
-        type: .+
+        type: "[a-zA-Z_\/]+"
         _method: GET
 
-bb.rest.classcontent.get_collection_by_category:
+bb.rest.classcontent.get_collection:
     pattern: /rest/{version}/classcontent
     defaults:
-        _action: getCollectionByCategoryAction
+        _action: getCollectionAction
         _controller: BackBee\Rest\Controller\ClassContentController
     requirements:
         type: .+

--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -23,6 +23,7 @@
 
 namespace BackBee\Controller;
 
+use BackBee\IApplication;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension;
@@ -32,8 +33,6 @@ use Symfony\Component\Form\Forms;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Validation;
-
-use BackBee\IApplication;
 
 /**
  * Base Controler
@@ -46,11 +45,15 @@ use BackBee\IApplication;
 class Controller implements ContainerAwareInterface
 {
     /**
-     * Current BackBee application
-     * @var \BackBee\BBApplication
+     * Current application
+     * @var \BackBee\IApplication
      */
-    protected $_application;
+    protected $application;
 
+    /**
+     * Current application's DIC
+     * @var BackBee\DependencyInjection\ContainerInterface
+     */
     protected $container;
 
     /**
@@ -62,13 +65,13 @@ class Controller implements ContainerAwareInterface
     public function __construct(IApplication $application = null)
     {
         if (null !== $application) {
-            $this->_application = $application;
+            $this->application = $application;
             $this->container = $application->getContainer();
         }
     }
 
     /**
-     * Returns current BackBee application
+     * Returns current application
      *
      * @access public
      * @return \BackBee\IApplication
@@ -78,18 +81,22 @@ class Controller implements ContainerAwareInterface
         return $this->container->get('bbapp');
     }
 
+    /**
+     * Application's dependency injection container setters
+     *
+     * @param ContainerInterface|null $container
+     */
     public function setContainer(ContainerInterface $container = null)
     {
         $this->container = $container;
-
-        $this->_application = $this->container->get('bbapp');
+        $this->application = null !== $container ? $this->container->get('bbapp') : null;
     }
 
     /**
      * Returns the application's DIC
      *
      * @access public
-     * @return ContainerBuilder
+     * @return ContainerInterface
      */
     public function getContainer()
     {
@@ -104,7 +111,7 @@ class Controller implements ContainerAwareInterface
      */
     public function getRequest()
     {
-        return $this->_application->getRequest();
+        return $this->application->getRequest();
     }
 
     /**
@@ -113,7 +120,7 @@ class Controller implements ContainerAwareInterface
      */
     public function getEntityManager()
     {
-        return $this->_application->getEntityManager();
+        return $this->application->getEntityManager();
     }
 
     /**
@@ -127,7 +134,8 @@ class Controller implements ContainerAwareInterface
         $formFactory = Forms::createFormFactoryBuilder()
             ->addExtension(new ValidatorExtension($validator))
             ->addExtension(new HttpFoundationExtension())
-            ->getFormFactory();
+            ->getFormFactory()
+        ;
 
         return $formFactory->createBuilder('form', $data);
     }
@@ -184,7 +192,7 @@ class Controller implements ContainerAwareInterface
      */
     public function getValidator()
     {
-        return $this->_application->getValidator();
+        return $this->application->getValidator();
     }
 
     /**

--- a/Rest/Controller/ARestController.php
+++ b/Rest/Controller/ARestController.php
@@ -23,6 +23,10 @@
 
 namespace BackBee\Rest\Controller;
 
+use BackBee\Controller\Controller;
+use BackBee\Rest\Exception\ValidationException;
+use BackBee\Rest\Formatter\FormatterInterface;
+use BackBee\Serializer\SerializerBuilder;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\SerializationContext;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -32,11 +36,6 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
-
-use BackBee\Controller\Controller;
-use BackBee\Rest\Exception\ValidationException;
-use BackBee\Rest\Formatter\FormatterInterface;
-use BackBee\Serializer\SerializerBuilder;
 
 /**
  * Abstract class for an api controller

--- a/Rest/Controller/AclController.php
+++ b/Rest/Controller/AclController.php
@@ -23,6 +23,8 @@
 
 namespace BackBee\Rest\Controller;
 
+use BackBee\Rest\Controller\Annotations as Rest;
+use BackBee\Rest\Exception\ValidationException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
@@ -30,9 +32,6 @@ use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
-
-use BackBee\Rest\Controller\Annotations as Rest;
-use BackBee\Rest\Exception\ValidationException;
 
 /**
  * User Controller
@@ -65,7 +64,7 @@ class AclController extends ARestController
      */
     public function getEntryCollectionAction(Request $request)
     {
-        $aclProvider = $this->getBBapp()->getSecurityContext()->getACLProvider();
+        $aclProvider = $this->getApplication()->getSecurityContext()->getACLProvider();
 
         /* @var $aclProvider \Symfony\Component\Security\Acl\Dbal\AclProvider */
         $aclProvider->findAcls();
@@ -76,10 +75,16 @@ class AclController extends ARestController
         ;
 
         if ($request->request->get('site_uid')) {
-            $site = $this->getApplication()->getEntityManager()->getRepository('BackBee\Site\Site')->find($request->request->get('site_uid'));
+            $site = $this->getEntityManager()->getRepository('BackBee\Site\Site')
+                ->find($request->request->get('site_uid'))
+            ;
 
             if (!$site) {
-                throw $this->createValidationException('site_uid', $request->request->get('site_uid'), 'Site is not valid: '.$request->request->get('site_uid'));
+                throw $this->createValidationException(
+                    'site_uid',
+                    $request->request->get('site_uid'),
+                    'Site is not valid: '.$request->request->get('site_uid')
+                );
             }
 
             $qb->leftJoin('g._site', 's')

--- a/Rest/Controller/BundleController.php
+++ b/Rest/Controller/BundleController.php
@@ -23,12 +23,6 @@
 
 namespace BackBee\Rest\Controller;
 
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Validator\Constraints as Assert;
-
 use BackBee\Bundle\BundleInterface;
 use BackBee\Rest\Controller\Annotations as Rest;
 use BackBee\Rest\Patcher\EntityPatcher;
@@ -36,6 +30,11 @@ use BackBee\Rest\Patcher\Exception\InvalidOperationSyntaxException;
 use BackBee\Rest\Patcher\Exception\UnauthorizedPatchOperationException;
 use BackBee\Rest\Patcher\OperationSyntaxValidator;
 use BackBee\Rest\Patcher\RightManager;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * REST API for application bundles

--- a/Rest/Controller/ClassContentController.php
+++ b/Rest/Controller/ClassContentController.php
@@ -165,6 +165,8 @@ class ClassContentController extends ARestController
      *
      * @return Symfony\Component\HttpFoundation\Response
      *
+     * @Rest\QueryParam(name="verbose", default=true, description="Response will contains classcontent definition and its own data")
+     *
      * @Rest\Pagination(default_count=25, max_count=100)
      */
     public function getCollectionAction($type, $start, $count)
@@ -186,6 +188,7 @@ class ClassContentController extends ARestController
      *
      * @Rest\QueryParam(name="mode", description="The render mode to use")
      * @Rest\QueryParam(name="page_uid", description="The page to set to application's renderer before rendering")
+     * @Rest\QueryParam(name="verbose", default=true, description="Response will contains classcontent definition and its own data")
      *
      * @Rest\ParamConverter(
      *   name="page", id_name="page_uid", id_source="query", class="BackBee\NestedNode\Page", required=false
@@ -210,7 +213,8 @@ class ClassContentController extends ARestController
                 $this->getApplication()->getRenderer()->render($content, $mode), 200, 'text/html'
             );
         } else {
-            $response = $this->createJsonResponse($this->updateClassContentImageUrl($content->jsonSerialize()));
+            $verbose = (boolean) $request->query->get('verbose', true);
+            $response = $this->createJsonResponse($this->updateClassContentImageUrl($content->jsonSerialize($verbose)));
         }
 
         return $response;
@@ -530,8 +534,9 @@ class ClassContentController extends ARestController
     private function formatClassContentCollection(Paginator $paginator)
     {
         $contents = [];
+        $verbose = (boolean) $this->getApplication()->getRequest()->query->get('verbose', true);
         foreach ($paginator as $content) {
-            $contents[] = $content->jsonSerialize();
+            $contents[] = $content->jsonSerialize($verbose);
         }
 
         return $this->updateClassContentCollectionImageUrl($contents);

--- a/Rest/Controller/ClassContentController.php
+++ b/Rest/Controller/ClassContentController.php
@@ -23,18 +23,17 @@
 
 namespace BackBee\Rest\Controller;
 
+use BackBee\AutoLoader\Exception\ClassNotFoundException;
+use BackBee\ClassContent\AClassContent;
+use BackBee\Rest\Controller\Annotations as Rest;
+use BackBee\Routing\RouteCollection;
+use BackBee\Utils\File\File;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Validator\Constraints as Assert;
-
-use BackBee\AutoLoader\Exception\ClassNotFoundException;
-use BackBee\ClassContent\AClassContent;
-use BackBee\Rest\Controller\Annotations as Rest;
-use BackBee\Routing\RouteCollection;
-use BackBee\Utils\File\File;
 
 /**
  * ClassContent API Controller
@@ -50,7 +49,7 @@ class ClassContentController extends ARestController
      * Contains every potential classcontent thumbnail base folder
      * @var array
      */
-    private $thumbnail_base_directory = null;
+    private $thumbnailBaseDir = null;
 
     /**
      * Returns category's datas if $id is valid
@@ -81,9 +80,7 @@ class ClassContentController extends ARestController
             $categories[] = array_merge(['id' => $id], $category->jsonSerialize());
         }
 
-        return $this->createJsonResponse($categories, 200, [
-            'Content-Range' => '0-'.(count($categories) - 1).'/'.count($categories)
-        ]);
+        return $this->addContentRangeHeadersToResponse($this->createJsonResponse($categories), $categories, 0);
     }
 
     /**
@@ -91,71 +88,26 @@ class ClassContentController extends ARestController
      *
      * @return Symfony\Component\HttpFoundation\Response
      *
-     * @Rest\QueryParam(name="category", description="Filter classcontent collection by provided category", requirements={
-     *     @Assert\NotBlank
-     * })
      * @Rest\Pagination(default_count=25, max_count=100)
      */
-    public function getCollectionByCategoryAction($start, $count, Request $request)
+    public function getCollectionAction($start, $count, Request $request)
     {
-        $category = $this->getCategoryManager()->getCategory($category_name = $request->query->get('category'));
-
-        if (null === $category) {
-            throw new NotFoundHttpException("`$category_name` is not a valid classcontent category.");
+        $contents = [];
+        $format = $this->getFormatParam();
+        $response = $this->createJsonResponse();
+        $categoryName = $request->query->get('category', null);
+        if (null !== $categoryName && AClassContent::JSON_DEFINITION_FORMAT !== $format) {
+            $contents = $this->getClassContentByCategory($categoryName, $start, $count);
+            $response->setData($this->formatClassContentCollection($contents));
+        } elseif (AClassContent::JSON_DEFINITION_FORMAT === $format) {
+            $response->setData($contents = $this->getClassContentDefinitionsByCategory($categoryName));
+            $start = 0;
+        } else {
+            $contents = $this->findContentsByCriterias($this->getAllClassContentClassnames(), $start, $count);
+            $response->setData($this->formatClassContentCollection($contents));
         }
-
-        $classnames = [];
-        foreach ($category->getBlocks() as $block) {
-            $classnames[] = $this->getClassnameByType($block->type);
-        }
-
-        $contents = $this->findContentsByCriterias($classnames, $start, $count);
-        $response = $this->createJsonResponse($this->formatClassContentCollection($contents));
 
         return $this->addContentRangeHeadersToResponse($response, $contents, $start);
-    }
-
-    /**
-     * Returns definition for provided type
-     *
-     * @param string $type
-     *
-     * @return Symfony\Component\HttpFoundation\Response
-     */
-    public function getDefinitionAction($type)
-    {
-        $classname = $this->getClassnameByType($type);
-
-        return $this->createJsonResponse($this->getDefinitionFromClassContent(new $classname()));
-    }
-
-    /**
-     * Returns definitions of every declared classcontent in current application; you can also filter it by:
-     *     - category name (provide 'category' as query parameter): returns definitions of every classcontent that
-     *     belong to provided category
-     *     - page uid (provide 'page_uid' as query parameter): returns definitions of every classcontent contained
-     *     by page's contentset
-     *
-     * @param Resquest $request
-     *
-     * @return Symfony\Component\HttpFoundation\Response
-     */
-    public function getDefinitionCollectionAction(Request $request)
-    {
-        $definitions = null;
-
-        if (null !== $category = $request->query->get('category', null)) {
-            $definitions = $this->getDefinitionsByCategory($category);
-        } elseif (null !== $page_uid = $request->query->get('page_uid', null)) {
-            $definitions = $this->getDefinitionsByPageUid($page_uid);
-        } else {
-            $definitions = $this->getAllElementDefinitions();
-            $definitions = array_merge($definitions, $this->getAllDefinitionsFromCategoryManager());
-        }
-
-        return $this->createJsonResponse($definitions, 200, [
-            'Content-Range' => '0-'.(count($definitions) - 1).'/'.count($definitions)
-        ]);
     }
 
     /**
@@ -165,11 +117,9 @@ class ClassContentController extends ARestController
      *
      * @return Symfony\Component\HttpFoundation\Response
      *
-     * @Rest\QueryParam(name="verbose", default=true, description="Response will contains classcontent definition and its own data")
-     *
      * @Rest\Pagination(default_count=25, max_count=100)
      */
-    public function getCollectionAction($type, $start, $count)
+    public function getCollectionByTypeAction($type, $start, $count)
     {
         $classname = $this->getClassnameByType($type);
         $contents = $this->findContentsByCriterias((array) $classname, $start, $count);
@@ -188,7 +138,6 @@ class ClassContentController extends ARestController
      *
      * @Rest\QueryParam(name="mode", description="The render mode to use")
      * @Rest\QueryParam(name="page_uid", description="The page to set to application's renderer before rendering")
-     * @Rest\QueryParam(name="verbose", default=true, description="Response will contains classcontent definition and its own data")
      *
      * @Rest\ParamConverter(
      *   name="page", id_name="page_uid", id_source="query", class="BackBee\NestedNode\Page", required=false
@@ -213,8 +162,8 @@ class ClassContentController extends ARestController
                 $this->getApplication()->getRenderer()->render($content, $mode), 200, 'text/html'
             );
         } else {
-            $verbose = (boolean) $request->query->get('verbose', true);
-            $response = $this->createJsonResponse($this->updateClassContentImageUrl($content->jsonSerialize($verbose)));
+            $response = $this->createJsonResponse();
+            $response->setData($this->encodeClassContent($content, $this->getFormatParam()));
         }
 
         return $response;
@@ -315,141 +264,6 @@ class ClassContentController extends ARestController
     }
 
     /**
-     * Returns provided content definition
-     *
-     * @param AClassContent $content
-     *
-     * @return array
-     */
-    private function getDefinitionFromClassContent(AClassContent $content)
-    {
-        $definition = $content->jsonSerialize();
-        $definition = $this->updateClassContentImageUrl($definition);
-        unset(
-            $definition['uid'],
-            $definition['state'],
-            $definition['created'],
-            $definition['modified'],
-            $definition['revision'],
-            $definition['elements'],
-            $definition['draft_uid'],
-            $definition['main_node']
-        );
-
-        return $definition;
-    }
-
-    /**
-     * Returns definitions of classcontent that belong to provided category name
-     *
-     * @param string $category_name
-     *
-     * @return array
-     */
-    private function getDefinitionsByCategory($category_name)
-    {
-        $category = $this->getCategoryManager()->getCategory($category_name);
-        if (null === $category) {
-            throw new NotFoundHttpException("`$category_name` is not a valid classcontent category.");
-        }
-
-        $definitions = [];
-        foreach ($category->getBlocks() as $block) {
-            $classname = $this->getClassnameByType($block->type);
-            $definitions[] = $this->getDefinitionFromClassContent(new $classname());
-        }
-
-        return $definitions;
-    }
-
-    /**
-     * Returns definitions of classcontent contained by provided page contentset
-     *
-     * @param string $page_uid
-     *
-     * @return array
-     */
-    private function getDefinitionsByPageUid($page_uid)
-    {
-        $classnames = $this->getApplication()->getEntityManager()->getConnection()->executeQuery(
-            'SELECT DISTINCT c.classname
-             FROM idx_content_content icc, content c, page p
-             WHERE p.uid = :page_uid AND p.contentset = icc.content_uid
-             AND icc.subcontent_uid = c.uid AND c.classname != :contentset_classname
-            ',
-            [
-                'page_uid'             => $page_uid,
-                'contentset_classname' => AClassContent::CLASSCONTENT_BASE_NAMESPACE.'ContentSet'
-            ]
-        )->fetchAll();
-
-        $definitions = [];
-        foreach ($classnames as $classname) {
-            $classname = $classname['classname'];
-            $definitions[] = $this->getDefinitionFromClassContent(new $classname());
-        }
-
-        return $definitions;
-    }
-
-    /**
-     * Returns definitions of every declared classcontent in current application
-     *
-     * @return array
-     */
-    private function getAllDefinitionsFromCategoryManager()
-    {
-        $classnames = [];
-        foreach ($this->getCategoryManager()->getCategories() as $category) {
-            foreach ($category->getBlocks() as $block) {
-                $classnames[] = $this->getClassnameByType($block->type);
-            }
-        }
-
-        return $this->getDefinitionsFromClassnames($classnames);
-    }
-
-    /**
-     * Returns definitions of every element classcontent
-     *
-     * @return array
-     */
-    private function getAllElementDefinitions()
-    {
-        $directory = $this->getApplication()->getBBDir().DIRECTORY_SEPARATOR.'ClassContent';
-        $classnames = array_map(
-            function ($path) use ($directory) {
-                return str_replace(
-                    [DIRECTORY_SEPARATOR, '\\\\'],
-                    [NAMESPACE_SEPARATOR, NAMESPACE_SEPARATOR],
-                    AClassContent::CLASSCONTENT_BASE_NAMESPACE.str_replace([$directory, '.yml'], ['', ''], $path)
-                );
-            },
-            File::getFilesRecursivelyByExtension($directory, 'yml')
-        );
-        $classnames[] = AClassContent::CLASSCONTENT_BASE_NAMESPACE.'ContentSet';
-
-        return $this->getDefinitionsFromClassnames($classnames);
-    }
-
-    /**
-     * Returns every classcontent definitions of provided classnames
-     *
-     * @param array $classnames
-     *
-     * @return array
-     */
-    private function getDefinitionsFromClassnames(array $classnames)
-    {
-        $definitions = [];
-        foreach ($classnames as $classname) {
-            $definitions[] = $this->getDefinitionFromClassContent(new $classname());
-        }
-
-        return $definitions;
-    }
-
-    /**
      * Returns classcontent datas if couple (type;uid) is valid
      *
      * @param string $type short namespace of a classcontent
@@ -474,6 +288,136 @@ class ClassContentController extends ARestController
         }
 
         return $content;
+    }
+
+    /**
+     * Returns classcontent by category
+     *
+     * @param  string  $name  category's name
+     * @param  integer $start
+     * @param  integer $count
+     * @return null|Paginator
+     */
+    private function getClassContentByCategory($name, $start, $count)
+    {
+        return $this->findContentsByCriterias($this->getClassContentClassnamesByCategory($name), $start, $count);
+    }
+
+    /**
+     * Returns all classcontents classnames containing by the given page
+     *
+     * @param string $pageUid The unique identifier of the page we want to get all classcontents
+     *
+     * @return array
+     */
+    private function getClassContentClassnamesByPageUid($pageUid)
+    {
+        $result = $this->getApplication()->getEntityManager()->getConnection()->executeQuery(
+            'SELECT DISTINCT c.classname
+             FROM idx_content_content icc, content c, page p
+             WHERE p.uid = :pageUid AND p.contentset = icc.content_uid
+             AND icc.subcontent_uid = c.uid AND c.classname != :contentset_classname
+            ',
+            [
+                'pageUid'              => $pageUid,
+                'contentset_classname' => AClassContent::CLASSCONTENT_BASE_NAMESPACE.'ContentSet',
+            ]
+        )->fetchAll();
+
+        $classnames = [];
+        foreach ($result as $classname) {
+            $classnames[] = $classname['classname'];
+        }
+
+        return $classnames;
+    }
+
+    /**
+     * Returns all classcontents classnames
+     *
+     * @return array An array that contains all classcontents classnames
+     */
+    private function getAllClassContentClassnames()
+    {
+        $classnames = [];
+        foreach ($this->getCategoryManager()->getCategories() as $category) {
+            foreach ($category->getBlocks() as $block) {
+                $classnames[] = $this->getClassnameByType($block->type);
+            }
+        }
+
+        return array_merge($this->getAllElementClassContentClassnames(), $classnames);
+    }
+
+    /**
+     * Returns all BackBee elements classcontents classnames
+     *
+     * @return array An array that contains all elements classcontents classnames
+     */
+    private function getAllElementClassContentClassnames()
+    {
+        $directory = $this->getApplication()->getBBDir().DIRECTORY_SEPARATOR.'ClassContent';
+        $classnames = array_map(
+            function ($path) use ($directory) {
+                return str_replace(
+                    [DIRECTORY_SEPARATOR, '\\\\'],
+                    [NAMESPACE_SEPARATOR, NAMESPACE_SEPARATOR],
+                    AClassContent::CLASSCONTENT_BASE_NAMESPACE.str_replace([$directory, '.yml'], ['', ''], $path)
+                );
+            },
+            File::getFilesRecursivelyByExtension($directory, 'yml')
+        );
+        $classnames[] = AClassContent::CLASSCONTENT_BASE_NAMESPACE.'ContentSet';
+
+        return $classnames;
+    }
+
+    /**
+     * Returns all classcontents classnames that belong to provided category
+     *
+     * @param  string $name The category name
+     * @return array
+     */
+    private function getClassContentClassnamesByCategory($name)
+    {
+        $category = $this->getCategoryManager()->getCategory($name);
+        if (null === $category) {
+            throw new NotFoundHttpException("`$name` is not a valid classcontent category.");
+        }
+
+        $classnames = [];
+        foreach ($category->getBlocks() as $block) {
+            $classnames[] = $this->getClassnameByType($block->type);
+        }
+
+        return $classnames;
+    }
+
+    /**
+     * Returns classcontent data with definition format (AContent::JSON_DEFAULT_FORMAT). If category name
+     * is provided it will returns every classcontent definition that belongs to this category, else it
+     * will returns all classcontents definitions.
+     *
+     * @param  string|null $name the category's name or null
+     * @return array
+     */
+    private function getClassContentDefinitionsByCategory($name = null)
+    {
+        $classnames = [];
+        if (null === $name) {
+            $classnames = $this->getAllClassContentClassnames();
+        } else {
+            $classnames = $this->getClassContentClassnamesByCategory($name);
+        }
+
+        $definitions = [];
+        foreach ($classnames as $classname) {
+            $definitions[] = $this->updateClassContentImageUrl(
+                (new $classname)->jsonSerialize(AClassContent::JSON_DEFINITION_FORMAT)
+            );
+        }
+
+        return $definitions;
     }
 
     /**
@@ -525,6 +469,42 @@ class ClassContentController extends ARestController
     }
 
     /**
+     * Returns AContent valid json format by looking at request query parameter and if no format found,
+     * it fallback to AContent::JSON_DEFAULT_FORMAT.
+     *
+     * @return integer One of AContent::$jsonFormats:
+     *                 JSON_DEFAULT_FORMAT | JSON_DEFINITION_FORMAT | JSON_CONCISE_FORMAT | JSON_INFO_FORMAT
+     */
+    private function getFormatParam()
+    {
+        $validFormats = array_keys(AClassContent::$jsonFormats);
+        $queryParamsKey = array_keys($this->getApplication()->getContainer()->get('request')->query->all());
+        $format = ($collection = array_intersect($validFormats, $queryParamsKey))
+            ? array_shift($collection)
+            : AClassContent::JSON_DEFAULT_FORMAT
+        ;
+
+        return AClassContent::$jsonFormats[$format];
+    }
+
+    /**
+     * Encodes classcontent according to provided format in request
+     *
+     * @param  AClassContent $content
+     * @param  integer       $format
+     * @return array
+     */
+    private function encodeClassContent(AClassContent $content, $format)
+    {
+        if (AClassContent::JSON_DEFINITION_FORMAT === $format) {
+            $classname = get_class($content);
+            $content = new $classname;
+        }
+
+        return $this->updateClassContentImageUrl($content->jsonSerialize($format));
+    }
+
+    /**
      * Converts Doctrine's paginator to php array
      *
      * @param Paginator $paginator the paginator to convert
@@ -534,27 +514,15 @@ class ClassContentController extends ARestController
     private function formatClassContentCollection(Paginator $paginator)
     {
         $contents = [];
-        $verbose = (boolean) $this->getApplication()->getRequest()->query->get('verbose', true);
-        foreach ($paginator as $content) {
-            $contents[] = $content->jsonSerialize($verbose);
+        if (AClassContent::JSON_DEFINITION_FORMAT === $format = $this->getFormatParam()) {
+            $contents[] = $this->encodeClassContent($paginator->getIterator()->current(), $format);
+        } else {
+            foreach ($paginator as $content) {
+                $contents[] = $this->encodeClassContent($content, $format);
+            }
         }
 
-        return $this->updateClassContentCollectionImageUrl($contents);
-    }
-
-    /**
-     * Update class content collection image url
-     *
-     * @param array $classcontents
-     */
-    private function updateClassContentCollectionImageUrl(array $classcontents)
-    {
-        $result = [];
-        foreach ($classcontents as $classcontent) {
-            $result[] = $this->updateClassContentImageUrl($classcontent);
-        }
-
-        return $result;
+        return $contents;
     }
 
     /**
@@ -564,26 +532,30 @@ class ClassContentController extends ARestController
      *
      * @return array
      */
-    private function updateClassContentImageUrl(array $classcontent)
+    private function updateClassContentImageUrl(array $data)
     {
-        $image_uri = '';
-        $url_type = RouteCollection::RESOURCE_URL;
-        if ('/' === $classcontent['image'][0]) {
-            $image_uri = $classcontent['image'];
-            $url_type = RouteCollection::IMAGE_URL;
+        if (!isset($data['image'])) {
+            return $data;
+        }
+
+        $imageUri = '';
+        $urlType = RouteCollection::RESOURCE_URL;
+        if ('/' === $data['image'][0]) {
+            $imageUri = $data['image'];
+            $urlType = RouteCollection::IMAGE_URL;
         } else {
-            $image_filepath = $this->getThumbnailBaseFolderPath().DIRECTORY_SEPARATOR.$classcontent['image'];
-            $base_folder = $this->getApplication()->getContainer()->getParameter('classcontent_thumbnail.base_folder');
+            $image_filepath = $this->getThumbnailBaseFolderPath().DIRECTORY_SEPARATOR.$data['image'];
+            $baseFolder = $this->getApplication()->getContainer()->getParameter('classcontent_thumbnail.base_folder');
             if (file_exists($image_filepath) && is_readable($image_filepath)) {
-                $image_uri = $base_folder.'/'.$classcontent['image'];
+                $imageUri = $baseFolder.'/'.$data['image'];
             } else {
-                $image_uri = $base_folder.'/'.'default_thumbnail.png';
+                $imageUri = $baseFolder.'/'.'default_thumbnail.png';
             }
         }
 
-        $classcontent['image'] = $this->getApplication()->getRouting()->getUri($image_uri, null, null, $url_type);
+        $data['image'] = $this->getApplication()->getRouting()->getUri($imageUri, null, null, $urlType);
 
-        return $classcontent;
+        return $data;
     }
 
     /**
@@ -593,39 +565,39 @@ class ClassContentController extends ARestController
      */
     private function getThumbnailBaseFolderPath()
     {
-        if (null === $this->thumbnail_base_directory) {
-            $base_folder = $this->getApplication()->getContainer()->getParameter('classcontent_thumbnail.base_folder');
-            $this->thumbnail_base_directory = array_map(function ($directory) use ($base_folder) {
+        if (null === $this->thumbnailBaseDir) {
+            $baseFolder = $this->getApplication()->getContainer()->getParameter('classcontent_thumbnail.base_folder');
+            $this->thumbnailBaseDir = array_map(function ($directory) use ($baseFolder) {
                 return str_replace(
                     DIRECTORY_SEPARATOR.DIRECTORY_SEPARATOR,
                     DIRECTORY_SEPARATOR,
-                    $directory.'/'.$base_folder
+                    $directory.'/'.$baseFolder
                 );
             }, $this->getApplication()->getResourceDir());
 
-            foreach ($this->thumbnail_base_directory as $directory) {
+            foreach ($this->thumbnailBaseDir as $directory) {
                 if (is_dir($directory)) {
-                    $this->thumbnail_base_directory = $directory;
+                    $this->thumbnailBaseDir = $directory;
                     break;
                 }
             }
         }
 
-        return $this->thumbnail_base_directory;
+        return $this->thumbnailBaseDir;
     }
 
     /**
      * Add 'Content-Range' parameters to $response headers
      *
-     * @param Response  $response   the response object
-     * @param Paginator $collection collection from where we extract Content-Range data
-     * @param integer   $start      the start value
+     * @param Response $response   the response object
+     * @param mixed    $collection collection from where we extract Content-Range data
+     * @param integer  $start      the start value
      */
-    private function addContentRangeHeadersToResponse(Response $response, Paginator $collection, $start)
+    private function addContentRangeHeadersToResponse(Response $response, $collection, $start)
     {
-        $count = 0;
-        foreach ($collection as $row) {
-            $count++;
+        $count = count($collection);
+        if ($collection instanceof Paginator) {
+            $count = count($collection->getIterator());
         }
 
         $last_result = $start + $count - 1;

--- a/Rest/Controller/GroupController.php
+++ b/Rest/Controller/GroupController.php
@@ -23,12 +23,11 @@
 
 namespace BackBee\Rest\Controller;
 
+use BackBee\Rest\Controller\Annotations as Rest;
+use BackBee\Security\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints as Assert;
-
-use BackBee\Rest\Controller\Annotations as Rest;
-use BackBee\Security\Group;
 
 /**
  * User Controller

--- a/Rest/Controller/LayoutController.php
+++ b/Rest/Controller/LayoutController.php
@@ -23,11 +23,10 @@
 
 namespace BackBee\Rest\Controller;
 
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Validator\Constraints as Assert;
-
 use BackBee\Rest\Controller\Annotations as Rest;
 use BackBee\Site\Layout;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @category    BackBee

--- a/Rest/Controller/PageController.php
+++ b/Rest/Controller/PageController.php
@@ -23,13 +23,6 @@
 
 namespace BackBee\Rest\Controller;
 
-use Doctrine\ORM\Tools\Pagination\Paginator;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Security\Acl\Permission\MaskBuilder;
-use Symfony\Component\Validator\Constraints as Assert;
-
 use BackBee\AutoLoader\Exception\ClassNotFoundException;
 use BackBee\ClassContent\AClassContent;
 use BackBee\Exception\InvalidArgumentException;
@@ -43,6 +36,12 @@ use BackBee\Rest\Patcher\OperationSyntaxValidator;
 use BackBee\Rest\Patcher\RightManager;
 use BackBee\Site\Layout;
 use BackBee\Workflow\State;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Acl\Permission\MaskBuilder;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * Page Controller

--- a/Rest/Controller/SecurityController.php
+++ b/Rest/Controller/SecurityController.php
@@ -23,15 +23,14 @@
 
 namespace BackBee\Rest\Controller;
 
+use BackBee\Rest\Controller\Annotations as Rest;
+use BackBee\Security\Token\AnonymousToken;
+use BackBee\Security\Token\BBUserToken;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Validator\Constraints as Assert;
-
-use BackBee\Rest\Controller\Annotations as Rest;
-use BackBee\Security\Token\AnonymousToken;
-use BackBee\Security\Token\BBUserToken;
 
 /**
  * Auth Controller
@@ -93,7 +92,7 @@ class SecurityController extends ARestController
             return $response;
         }
 
-        $securityContext = $this->_application->getSecurityContext();
+        $securityContext = $this->getApplication()->getSecurityContext();
 
         if (null === $securityContext) {
             $response = new Response();

--- a/Rest/Controller/TestController.php
+++ b/Rest/Controller/TestController.php
@@ -23,11 +23,10 @@
 
 namespace BackBee\Rest\Controller;
 
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-
 use BackBee\Controller\Controller;
 use BackBee\Security\Encoder\RequestSignatureEncoder;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Test api key controller

--- a/Rest/Controller/UserController.php
+++ b/Rest/Controller/UserController.php
@@ -23,15 +23,14 @@
 
 namespace BackBee\Rest\Controller;
 
+use BackBee\Rest\Controller\Annotations as Rest;
+use BackBee\Security\User;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Validator\Constraints as Assert;
-
-use BackBee\Rest\Controller\Annotations as Rest;
-use BackBee\Security\User;
 
 /**
  * User Controller


### PR DESCRIPTION
This option is passed as query parameter; it's necessary to lighten get classcontent action response;

The reduction is done by unsetting classcontent entry provided by classcontent definition (like maxentry, minentry, accept and properties)

I did some benchmarks:

- get article collection (26 items) with verbose true: response with over 20k lines
- get article collection (26 items) with verbose false: response with ~9k lines

It still heavy so we have to discuss about this with @crouillon.