### PR TITLE
[RFR] - Updated respect/validation version to last stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "swiftmailer/swiftmailer": "5.3.0",
         "jms/serializer": "0.16.0",
         "jms/metadata": "1.5.1",
-        "respect/validation": "0.7.*@dev",
+        "respect/validation": "~0.6",
         "willdurand/jsonp-callback-validator": "~1.0",
         "symfony/expression-language": "2.5.8",
         "backbee/utils": "1.0.*@dev"


### PR DESCRIPTION
``0.7.*@dev`` branch of ``respect/validation`` dependencies no longer exists.

This pull request update to the latest "stable" ``0.6.x`` branch.