### PR TITLE
[RFR] [Validator] #170 Don't use validator if data is empty

### DIFF
--- a/Validator/ArrayValidator.php
+++ b/Validator/ArrayValidator.php
@@ -57,7 +57,7 @@ class ArrayValidator extends AValidator
                 }
 
                 if (true === $do_treatment) {
-                    if (true === isset($cConfig[self::CONFIG_PARAMETER_VALIDATOR])) {
+                    if (true === isset($cConfig[self::CONFIG_PARAMETER_VALIDATOR]) && false === empty($data)) {
                         foreach ($cConfig[self::CONFIG_PARAMETER_VALIDATOR] as $validator => $validator_conf) {
                             $this->doGeneralValidator($data, $key, $validator, $validator_conf, $errors);
                         }

--- a/Validator/ArrayValidator.php
+++ b/Validator/ArrayValidator.php
@@ -50,11 +50,13 @@ class ArrayValidator extends AValidator
         foreach ($datas as $key => $data) {
             if (null !== $cConfig = $this->getData($key, $form_config)) {
                 
-                $set_empty = isset($cConfig[self::CONFIG_PARAMETER_SET_EMPTY]) && true === $cConfig[self::CONFIG_PARAMETER_SET_EMPTY];
+                if ($set_empty = isset($cConfig[self::CONFIG_PARAMETER_SET_EMPTY])) {
+                    $set_empty =  true === $cConfig[self::CONFIG_PARAMETER_SET_EMPTY];
+                }
                 
                 $do_treatment = true;
                 if (isset($cConfig[self::CONFIG_PARAMETER_MANDATORY])) {
-                    if (false === $cConfig[self::CONFIG_PARAMETER_MANDATORY] && (true === empty($data) && false === $set_empty)) {
+                    if (false === $cConfig[self::CONFIG_PARAMETER_MANDATORY] && empty($data && !$set_empty)) {
                         $do_treatment = false;
                     }
                 }

--- a/Validator/ArrayValidator.php
+++ b/Validator/ArrayValidator.php
@@ -56,7 +56,7 @@ class ArrayValidator extends AValidator
                 
                 $do_treatment = true;
                 if (isset($cConfig[self::CONFIG_PARAMETER_MANDATORY])) {
-                    if (false === $cConfig[self::CONFIG_PARAMETER_MANDATORY] && empty($data && !$set_empty)) {
+                    if (false === $cConfig[self::CONFIG_PARAMETER_MANDATORY] && empty($data) && !$set_empty) {
                         $do_treatment = false;
                     }
                 }

--- a/Validator/ArrayValidator.php
+++ b/Validator/ArrayValidator.php
@@ -49,26 +49,36 @@ class ArrayValidator extends AValidator
     {
         foreach ($datas as $key => $data) {
             if (null !== $cConfig = $this->getData($key, $form_config)) {
+                
+                $set_empty = isset($cConfig[self::CONFIG_PARAMETER_SET_EMPTY]) && true === $cConfig[self::CONFIG_PARAMETER_SET_EMPTY];
+                
                 $do_treatment = true;
-                if (true === isset($cConfig[self::CONFIG_PARAMETER_MANDATORY]) &&
-                    false === $cConfig[self::CONFIG_PARAMETER_MANDATORY] &&
-                    true === empty($data)) {
-                    $do_treatment = false;
+                if (isset($cConfig[self::CONFIG_PARAMETER_MANDATORY])) {
+                    if (false === $cConfig[self::CONFIG_PARAMETER_MANDATORY] && (true === empty($data) && false === $set_empty)) {
+                        $do_treatment = false;
+                    }
                 }
 
                 if (true === $do_treatment) {
-                    if (true === isset($cConfig[self::CONFIG_PARAMETER_VALIDATOR]) && false === empty($data)) {
-                        foreach ($cConfig[self::CONFIG_PARAMETER_VALIDATOR] as $validator => $validator_conf) {
-                            $this->doGeneralValidator($data, $key, $validator, $validator_conf, $errors);
+                    if (true === isset($cConfig[self::CONFIG_PARAMETER_VALIDATOR])) {
+                        
+                        $do_treatment = true;
+                        if (true === empty($data) && true === $set_empty) {
+                            $do_treatment = false;
+                        }
+                        
+                        if (true === $do_treatment) {
+                            foreach ($cConfig[self::CONFIG_PARAMETER_VALIDATOR] as $validator => $validator_conf) {
+                                $this->doGeneralValidator($data, $key, $validator, $validator_conf, $errors);
+                            }
                         }
                     }
 
                     $do_set = true;
-                    if (true === isset($cConfig[self::CONFIG_PARAMETER_SET_EMPTY])) {
-                        if (false === $cConfig[self::CONFIG_PARAMETER_SET_EMPTY] && true === empty($data)) {
-                            $do_set = false;
-                        }
+                    if (false === $set_empty && true === empty($data)) {
+                        $do_set = false;
                     }
+                    
                     if (true === $do_set) {
                         $this->setData($key, $data, $array);
                     }

--- a/Validator/EntityValidator.php
+++ b/Validator/EntityValidator.php
@@ -82,7 +82,7 @@ class EntityValidator extends AValidator
                 }
 
                 if (true === $do_treatment) {
-                    if (true === isset($cConfig[self::CONFIG_PARAMETER_VALIDATOR])) {
+                    if (true === isset($cConfig[self::CONFIG_PARAMETER_VALIDATOR]) && false === empty($data)) {
                         foreach ($cConfig[self::CONFIG_PARAMETER_VALIDATOR] as $validator => $validator_conf) {
                             if (self::UNIQUE_VALIDATOR === $validator) {
                                 $this->doUniqueValidator($entity, $errors, $key, $data, $validator_conf);

--- a/Validator/EntityValidator.php
+++ b/Validator/EntityValidator.php
@@ -78,7 +78,7 @@ class EntityValidator extends AValidator
                 
                 $do_treatment = true;
                 if (isset($cConfig[self::CONFIG_PARAMETER_MANDATORY])) {
-                    if (false === $cConfig[self::CONFIG_PARAMETER_MANDATORY] && empty($data && !$set_empty)) {
+                    if (false === $cConfig[self::CONFIG_PARAMETER_MANDATORY] && empty($data) && !$set_empty) {
                         $do_treatment = false;
                     }
                 }

--- a/Validator/EntityValidator.php
+++ b/Validator/EntityValidator.php
@@ -1,22 +1,22 @@
 <?php
 
 /*
- * Copyright (c) 2011-2013 Lp digital system
+ * Copyright (c) 2011-2015 Lp digital system
  *
- * This file is part of BackBuilder5.
+ * This file is part of BackBee.
  *
- * BackBuilder5 is free software: you can redistribute it and/or modify
+ * BackBee is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * BackBuilder5 is distributed in the hope that it will be useful,
+ * BackBee is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with BackBuilder5. If not, see <http://www.gnu.org/licenses/>.
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace BackBee\Validator;
@@ -26,8 +26,8 @@ use Doctrine\ORM\EntityManager;
 /**
  * Entity's validator
  *
- * @category    BackBuilder
- * @package     BackBuilder\Validator
+ * @category    BackBee
+ * @package     BackBee\Validator
  * @copyright   Lp digital system
  * @author      f.kroockmann <florian.kroockmann@lp-digital.fr>
  */
@@ -72,11 +72,13 @@ class EntityValidator extends AValidator
             if (true === isset($config[$key])) {
                 $cConfig = $config[$key];
                 
-                $set_empty = isset($cConfig[self::CONFIG_PARAMETER_SET_EMPTY]) && true === $cConfig[self::CONFIG_PARAMETER_SET_EMPTY];
+                if ($set_empty = isset($cConfig[self::CONFIG_PARAMETER_SET_EMPTY])) {
+                    $set_empty =  true === $cConfig[self::CONFIG_PARAMETER_SET_EMPTY];
+                }
                 
                 $do_treatment = true;
                 if (isset($cConfig[self::CONFIG_PARAMETER_MANDATORY])) {
-                    if (false === $cConfig[self::CONFIG_PARAMETER_MANDATORY] && (true === empty($data) && false === $set_empty)) {
+                    if (false === $cConfig[self::CONFIG_PARAMETER_MANDATORY] && empty($data && !$set_empty)) {
                         $do_treatment = false;
                     }
                 }

--- a/Validator/Tests/EntityValidatorTest.php
+++ b/Validator/Tests/EntityValidatorTest.php
@@ -26,6 +26,7 @@ namespace BackBee\Validator\Tests;
 use BackBee\Tests\Mock\MockBBApplication;
 use BackBee\Validator\Tests\Mock\MockEntity;
 use BackBee\Validator\Tests\Mock\MockEntity2;
+use BackBee\Validator\EntityValidator;
 
 /**
  * Entity's validator
@@ -132,7 +133,7 @@ class EntityValidatorTest extends \PHPUnit_Framework_TestCase
         //Test data
         $this->generateData();
 
-        $this->entity_validator = new \BackBee\Validator\EntityValidator($this->em);
+        $this->entity_validator = new EntityValidator($this->em);
     }
 
     private function generateData()


### PR DESCRIPTION
On validate function it's useless to use validator for example "image or email" if the data is empty cause a property set_empty exist.