### PR TITLE
[RFR] [Config] #172 + updated security.yml to request 'secret_key' instead of 'bb5_secret_key'

### DIFF
--- a/Config/security.yml
+++ b/Config/security.yml
@@ -28,7 +28,7 @@ providers:
     bb_user:
         entity:
             class: BackBee\Security\User
-        secret: %bb5_secret_key%
+        secret: %secret_key%
     public_key:
         entity:
             class: BackBee\Security\User


### PR DESCRIPTION
We want to remove every reference to this project old name (BackBuilder, BackBuilder5, bb5).