### PR TITLE
[RFR] [Rest] #176 changed classcontent's category route pattern

### DIFF
--- a/ClassContent/Category.php
+++ b/ClassContent/Category.php
@@ -43,7 +43,7 @@ class Category implements \JsonSerializable
      * Contains many \stdClass which hold informations (label, description, type, visible) about blocks
      * @var array
      */
-    private $blocks;
+    private $blocks = [];
 
     /**
      * Category's contructor

--- a/Config/route.yml
+++ b/Config/route.yml
@@ -287,7 +287,7 @@ bb.rest.layout.delete:
         _method: DELETE
 
 bb.rest.classcontent.category.get:
-    pattern: /rest/{version}/classcontent/category/{id}
+    pattern: /rest/{version}/classcontent-category/{id}
     defaults:
         _action: getCategoryAction
         _controller: BackBee\Rest\Controller\ClassContentController
@@ -295,7 +295,7 @@ bb.rest.classcontent.category.get:
         _method: GET
 
 bb.rest.classcontent.category.get_collection:
-    pattern: /rest/{version}/classcontent/category
+    pattern: /rest/{version}/classcontent-category
     defaults:
         _action: getCategoryCollectionAction
         _controller: BackBee\Rest\Controller\ClassContentController

--- a/Rest/Controller/AclController.php
+++ b/Rest/Controller/AclController.php
@@ -287,7 +287,10 @@ class AclController extends ARestController
             $securityIdentity = new UserSecurityIdentity($sid, 'BackBee\Security\Group');
 
             // convert values to booleans
-            $permissions = array_map('BackBee\Utils\String::toBoolean', $permissions);
+            $permissions = array_map(function ($val) {
+                return \BackBee\Utils\String::toBoolean((string) $val);
+            }, $permissions);
+
             // remove false values
             $permissions = array_filter($permissions);
             $permissions = array_keys($permissions);

--- a/Rest/Controller/ClassContentController.php
+++ b/Rest/Controller/ClassContentController.php
@@ -62,7 +62,7 @@ class ClassContentController extends ARestController
     {
         $category = $this->getCategoryManager()->getCategory($id);
         if (null === $category) {
-            throw new NotFoundHttpException("No classcontent category exists for id `$id`.");
+            throw new NotFoundHttpException("Classcontent's category `$id` not found.");
         }
 
         return $this->createJsonResponse($category);

--- a/Rest/Test/RestTestCase.php
+++ b/Rest/Test/RestTestCase.php
@@ -50,7 +50,11 @@ class RestTestCase extends TestCase
      */
     protected static function requestPost($uri, array $data = [], $contentType = 'application/json', $sign = false)
     {
-        $request = new Request([], $data, [], [], [], ['REQUEST_URI' => $uri, 'CONTENT_TYPE' => $contentType, 'REQUEST_METHOD' => 'POST']);
+        $request = new Request([], $data, [], [], [], [
+            'REQUEST_URI'    => $uri,
+            'CONTENT_TYPE'   => $contentType,
+            'REQUEST_METHOD' => 'POST',
+        ]);
 
         if ($sign) {
             self::signRequest($request);
@@ -69,7 +73,11 @@ class RestTestCase extends TestCase
      */
     protected static function requestPut($uri, array $data = [], $contentType = 'application/json', $sign = false)
     {
-        $request = new Request([], $data, [], [], [], ['REQUEST_URI' => $uri, 'CONTENT_TYPE' => $contentType, 'REQUEST_METHOD' => 'PUT']);
+        $request = new Request([], $data, [], [], [], [
+            'REQUEST_URI'    => $uri,
+            'CONTENT_TYPE'   => $contentType,
+            'REQUEST_METHOD' => 'PUT'
+        ]);
 
         if ($sign) {
             self::signRequest($request);
@@ -88,7 +96,11 @@ class RestTestCase extends TestCase
      */
     protected static function requestPatch($uri, array $operations = [], $contentType = 'application/json', $sign = false)
     {
-        $request = new Request([], $operations, [], [], [], ['REQUEST_URI' => $uri, 'CONTENT_TYPE' => $contentType, 'REQUEST_METHOD' => 'PATCH']);
+        $request = new Request([], $operations, [], [], [], [
+            'REQUEST_URI' => $uri,
+            'CONTENT_TYPE' => $contentType,
+            'REQUEST_METHOD' => 'PATCH'
+        ]);
 
         if ($sign) {
             self::signRequest($request);

--- a/Rest/Tests/Controller/ClassContentControllerTest.php
+++ b/Rest/Tests/Controller/ClassContentControllerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace BackBee\Rest\Tests\Controller;
+
+use BackBee\ClassContent\Category;
+use BackBee\Rest\Controller\ClassContentController;
+use BackBee\Tests\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+class ClassContentControllerTest extends TestCase
+{
+    public function testGetCategory()
+    {
+        $app = $this->getApplication();
+        file_put_contents(
+            $app->getRepository().DIRECTORY_SEPARATOR.'ClassContent'.DIRECTORY_SEPARATOR.'test.yml',
+            Yaml::dump([
+                'test' => [
+                    'properties' => [
+                        'name'        => 'Test content',
+                        'description' => 'ClassContentController test content description',
+                        'category'    => ['Test'],
+                    ],
+                ],
+            ])
+        );
+
+        $categoryManager = $app->getContainer()->get('classcontent.category_manager');
+        $controller = new ClassContentController($app);
+
+        // Test ClassContentController::getCategoryCollectionAction
+        $expectedResponse = [];
+        foreach ($categoryManager->getCategories() as $id => $category) {
+            $expectedResponse[] = array_merge(['id' => $id], $category->jsonSerialize());
+        }
+
+        $allCategoriesResponse = $controller->getCategoryCollectionAction();
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $allCategoriesResponse);
+        $this->assertEquals(json_encode($expectedResponse), $allCategoriesResponse->getContent());
+
+        // Test ClassContentController::getCategoryCollectionAction
+        $expectedResponse = $categoryManager->getCategory('test');
+
+        $categoryResponse = $controller->getCategoryAction('test');
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $categoryResponse);
+        $this->assertEquals(json_encode($expectedResponse), $categoryResponse->getContent());
+    }
+
+    /**
+     * @expectedException        Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedExceptionMessage Classcontent's category `invalid` not found.
+     */
+    public function testGetInvalidCategory()
+    {
+        $controller = new ClassContentController($this->getApplication());
+        $controller->getCategoryAction('invalid');
+    }
+}

--- a/Rest/Tests/Controller/UserControllerTest.php
+++ b/Rest/Tests/Controller/UserControllerTest.php
@@ -405,7 +405,7 @@ class UserControllerTest extends RestTestCase
      * @param  BackBee\Security\User                     $user
      * @return self
      */
-    protected static function signRequest(Request $request, BackBee\Security\User $user = null)
+    protected static function signRequest(Request $request, User $user = null)
     {
         if (null === $user) {
             $user = $this->user;

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -59,15 +59,49 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $BackBee_autoloader = new AutoLoader();
 
         $BackBee_autoloader->setApplication($this->getBBApp())
-                ->register()
-                ->registerNamespace('BackBee\Bundle\Tests', implode(DIRECTORY_SEPARATOR, array($this->root_folder, 'bundle', 'Tests')))
-                ->registerNamespace('BackBee\Bundle', implode(DIRECTORY_SEPARATOR, array($this->root_folder, 'bundle')))
-                ->registerNamespace('BackBee\Tests\Fixtures', implode(DIRECTORY_SEPARATOR, array($this->repository_folder, 'Fixtures')))
-                ->registerNamespace('BackBee\ClassContent\Repository', implode(DIRECTORY_SEPARATOR, array($this->repository_folder, 'ClassContent', 'Repositories')))
-                ->registerNamespace('BackBee\Renderer\Helper', implode(DIRECTORY_SEPARATOR, array($this->repository_folder, 'Templates', 'helpers')))
-                ->registerNamespace('BackBee\Event\Listener', implode(DIRECTORY_SEPARATOR, array($this->repository_folder, 'Listeners')))
-                ->registerNamespace('BackBee\Services\Public', implode(DIRECTORY_SEPARATOR, array($this->repository_folder, 'Services', 'Public')))
-                ->registerNamespace('Doctrine\Tests', implode(DIRECTORY_SEPARATOR, array($this->root_folder, 'vendor', 'doctrine', 'orm', 'tests', 'Doctrine', 'Tests')));
+            ->register()
+            ->registerNamespace('BackBee\Bundle\Tests', implode(DIRECTORY_SEPARATOR, [
+                $this->root_folder,
+                'bundle',
+                'Tests'
+            ]))
+            ->registerNamespace('BackBee\Bundle', implode(DIRECTORY_SEPARATOR, [
+                $this->root_folder,
+                'bundle'
+            ]))
+            ->registerNamespace('BackBee\Tests\Fixtures', implode(DIRECTORY_SEPARATOR, [
+                $this->repository_folder,
+                'Fixtures'
+            ]))
+            ->registerNamespace('BackBee\ClassContent\Repository', implode(DIRECTORY_SEPARATOR, [
+                $this->repository_folder,
+                'ClassContent',
+                'Repositories'
+            ]))
+            ->registerNamespace('BackBee\Renderer\Helper', implode(DIRECTORY_SEPARATOR, [
+                $this->repository_folder,
+                'Templates',
+                'helpers'
+            ]))
+            ->registerNamespace('BackBee\Event\Listener', implode(DIRECTORY_SEPARATOR, [
+                $this->repository_folder,
+                'Listeners'
+            ]))
+            ->registerNamespace('BackBee\Services\Public', implode(DIRECTORY_SEPARATOR, [
+                $this->repository_folder,
+                'Services',
+                'Public'
+            ]))
+            ->registerNamespace('Doctrine\Tests', implode(DIRECTORY_SEPARATOR, [
+                $this->root_folder,
+                'vendor',
+                'doctrine',
+                'orm',
+                'tests',
+                'Doctrine',
+                'Tests'
+            ]))
+        ;
     }
 
     public function getClassContentDir()
@@ -87,10 +121,11 @@ class TestCase extends \PHPUnit_Framework_TestCase
     public function load($namespace)
     {
         try {
-            if (!file_exists($this->root_folder.DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, $namespace).'.php')) {
+            $file = $this->root_folder.DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, $namespace).'.php';
+            if (!file_exists($file)) {
                 throw new \Exception('BackBeeTestUnit could not find file associeted this namespace '.$namespace);
             } else {
-                include_once $this->root_folder.DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, $namespace).'.php';
+                include_once $file;
             }
         } catch (\Exception $e) {
             echo $e->getMessage();
@@ -206,6 +241,17 @@ class TestCase extends \PHPUnit_Framework_TestCase
         }
 
         return $this->bbapp;
+    }
+
+    /**
+     * Returns application
+     *
+     * @param  array|null $config
+     * @return BackBee\IApplication
+     */
+    public function getApplication(array $config = null)
+    {
+        return $this->getBBApp($config);
     }
 
     public function getContainer()


### PR DESCRIPTION
Currently, to get all classcontent's categories:

``/rest/{version}/classcontent/category``

And to get classcontent's specific category:

``/rest/{version}/classcontent/category/{id}``

This PR change these patterns:

- from ``/rest/{version}/classcontent/category`` to ``/rest/{version}/classcontent-category``
- from ``/rest/{version}/classcontent/category/{id}`` to ``/rest/{version}/classcontent-category/{id}``

These changes occur to avoid conflict with __get classcontent by type pattern__: ``/rest/{version}/classcontent/{type}``