### PR TITLE
#194 + updated .travis.yml to get last version of composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,13 @@ php:
 matrix:
     allow_failures:
         - php: hhvm-nightly
-        - php: 5.6
 
-install: composer install --prefer-dist --no-interaction
+before_script:
+  - curl -s http://getcomposer.org/installer | php
+  - php composer.phar install  --dev --no-interaction --prefer-source
 
 script:
-    - phpunit
+  - ./vendor/bin/phpunit
 
 notifications:
     email: false


### PR DESCRIPTION
Removed PHP 5.6 from ``allow_failure`` section and updated composer version.