### PR TITLE
[RFR] #196 + updated composer.json and project's dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,17 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/symfony": "2.3.23",
-        "doctrine/orm": "2.4.6",
-        "doctrine/dbal": "2.4.3",
-        "twig/twig": "1.16.2",
-        "twig/extensions" : "1.1.0",
-        "swiftmailer/swiftmailer": "5.3.0",
+        "symfony/symfony": "2.3.24",
+        "doctrine/orm": "2.4.7",
+        "doctrine/dbal": "2.4.4",
+        "twig/twig": "1.17.0",
+        "twig/extensions" : "1.2.0",
+        "swiftmailer/swiftmailer": "5.3.1",
         "jms/serializer": "0.16.0",
         "jms/metadata": "1.5.1",
-        "respect/validation": "~0.6",
-        "willdurand/jsonp-callback-validator": "~1.0",
-        "symfony/expression-language": "2.5.8",
+        "respect/validation": "0.7.3",
+        "willdurand/jsonp-callback-validator": "1.1.0",
+        "symfony/expression-language": "2.6.3",
         "backbee/utils": "1.0.*@dev"
     },
     "autoload": {
@@ -35,7 +35,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "4.3.5",
+        "phpunit/phpunit": "4.4.2",
         "phpunit/dbunit": "1.3.1",
         "mikey179/vfsStream": "1.4.0",
         "fzaninotto/faker": "1.4.0"


### PR DESCRIPTION
Some updates are very effective like ``twig`` which improve the cache management or ``symfony`` which brings improvements about security.

Note that ``doctrine/dbal`` breaks compatibilty with backbee since version >= 2.5. I didn't test with ``doctrine/orm`` version 2.5 or later yet cause it still in alpha release.