### PR TITLE
Add optional site parameter in getRoot function #210

### DIFF
--- a/NestedNode/Repository/PageRepository.php
+++ b/NestedNode/Repository/PageRepository.php
@@ -347,23 +347,31 @@ class PageRepository extends NestedNodeRepository
 
     /**
      * Returns the root page for $site
-     * @param  \BackBee\Site\Site            $site             the site to test
-     * @param  array                         $restrictedStates optional, limit to pages having provided states
+     * @param \BackBee\Site\Site $site   optional, the site to test
+     * @param array $restrictedStates        optional, limit to pages having provided states
      * @return \BackBee\NestedNode\Page|NULL
      */
-    public function getRoot(Site $site, array $restrictedStates = array())
+    public function getRoot(Site $site = null, array $restrictedStates = array())
     {
         $q = $this->createQueryBuilder('p')
-            ->andSiteIs($site)
-            ->andParentIs(null)
-            ->setMaxResults(1)
-        ;
+                ->andParentIs(null)
+                ->setMaxResults(1);
+
+        if (null !== $site) {
+            $q->andSiteIs($site);
+        }
 
         if (0 < count($restrictedStates)) {
             $q->andStateIsIn($restrictedStates);
         }
 
-        return $q->getQuery()->getOneOrNullResult();
+        $result = $q->getQuery()->getResult();
+
+        if (count($result) > 1) {
+            new \LogicException('PageRepository getRoot need site parameter because multisite detected', 500);
+        }
+
+        return array_pop($result);
     }
 
     /**

--- a/NestedNode/Tests/Repository/PageRepositoryTest.php
+++ b/NestedNode/Tests/Repository/PageRepositoryTest.php
@@ -333,13 +333,27 @@ class PageRepositoryTest extends TestCase
     }
 
     /**
-     * @covers \BackBee\NestedNode\Repository\PageRepository::getRoot
+     * @ExpectedException \LogicalException
      */
     public function testGetRoot()
     {
         $this->assertEquals($this->root, $this->repo->getRoot($this->root->getSite()));
         $this->assertEquals($this->root, $this->repo->getRoot($this->root->getSite(), array(Page::STATE_HIDDEN)));
+        $this->assertEquals($this->root, $this->repo->getRoot());
         $this->assertNull($this->repo->getRoot($this->root->getSite(), array(Page::STATE_ONLINE)));
+    }
+
+    /**
+     * @covers \BackBee\NestedNode\Repository\PageRepository::getRoot
+     */
+    public function testGetRootException()
+    {
+        $site = new \BackBee\Site\Site();
+        $site->setLabel('multi site')->setServerName('multi site');
+        $this->getEntityManager()->persist($site);
+        $this->getEntityManager()->flush($site);
+
+        $this->repo->getRoot();
     }
 
     /**


### PR DESCRIPTION
This enhancement is for ease getRoot function in mono site configuration.
But if there is multiple site enabled getRoot have to raise an exception in case of site is null.