### PR TITLE
[RFR] - Uncouple Logger from errorHandler/exceptionHandler

### DIFF
--- a/AutoLoader/AutoLoader.php
+++ b/AutoLoader/AutoLoader.php
@@ -115,12 +115,6 @@ class AutoLoader implements DumpableServiceInterface, DumpableServiceProxyInterf
     private $_dispatcher;
 
     /**
-     * Application logger
-     * @var \BackBee\Logging\Logger
-     */
-    private $_logger;
-
-    /**
      * define if autolader is already restored by container or not
      * @var boolean
      */
@@ -130,7 +124,6 @@ class AutoLoader implements DumpableServiceInterface, DumpableServiceProxyInterf
      * Class constructor
      * @param \BackBee\BBApplication    $application Optionnal BackBee Application
      * @param \BackBee\Event\Dispatcher $dispatcher  Optionnal events dispatcher
-     * @param \BackBee\Logging\Logger   $logger      Optionnal logging engine
      */
     public function __construct(BBApplication $application = null, Dispatcher $dispatcher = null)
     {

--- a/BBApplication.php
+++ b/BBApplication.php
@@ -27,6 +27,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Debug\Debug;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -132,6 +133,9 @@ class BBApplication implements ApplicationInterface, DumpableServiceInterface, D
 
         $this->_initAnnotationReader();
         $this->_initContainer();
+        if ($this->isDebugMode()) {
+            Debug::enable();
+        }
         $this->_initEnvVariables();
         $this->_initAutoloader();
         $this->_initContentWrapper();
@@ -1180,7 +1184,6 @@ class BBApplication implements ApplicationInterface, DumpableServiceInterface, D
         $definition = new Definition('Doctrine\Common\EventManager');
         $definition->addMethodCall('addEventListener', array($r->getConstants(), new Reference('doctrine.listener')));
         $this->_container->setDefinition('doctrine.event_manager', $definition);
-        $evm = $this->_container->get('doctrine.event_manager');
 
         try {
             $logger_id = 'logging';

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "respect/validation": "0.7.3",
         "willdurand/jsonp-callback-validator": "1.1.0",
         "symfony/expression-language": "2.6.3",
-        "backbee/utils": "1.0.*@dev"
+        "backbee/utils": "1.0.*@dev",
+        "symfony/var-dumper": "~2.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
See #244

This will uncouple error/exception handling from rendering, and also I've added the new [Symfony VarDumper](http://symfony.com/blog/new-in-symfony-2-6-vardumper-component) which is very powerfull to debug, and also it won't break the script.


![real_debug_tools](https://cloud.githubusercontent.com/assets/1247388/6169062/20c8259c-b2cb-11e4-99d2-6bfa2077abdf.png)