### PR TITLE
#250 fix Error on autoloading class Backbee\Validator\Rules\Image

### DIFF
--- a/Validator/Rules/Image.php
+++ b/Validator/Rules/Image.php
@@ -21,8 +21,9 @@
  * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
  */
 
-namespace Respect\Validation\Rules;
+namespace BackBee\Validator\Rules;
 
+use Respect\Validation\Rules\AbstractRule;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class Image extends AbstractRule


### PR DESCRIPTION
The autoloader expected class "BackBee\Validator\Rules\Image" to be defined in file "/vendor/backbee/backbee/Validator/Rules/Image.php". The file was found but the class was not in it, the class name or namespace probably has a typo.