### PR TITLE
[RFR] Introduced a new way to execute and configure error pages

### DIFF
--- a/Config/events.yml
+++ b/Config/events.yml
@@ -82,6 +82,7 @@ kernel.request:
 kernel.exception:
     listeners:
         - [@rest.listener.exception, onKernelException]
+        - [@exception.listener, onKernelException]
 
 kernel.controller:
     listeners:

--- a/Config/services/error.yml
+++ b/Config/services/error.yml
@@ -1,0 +1,6 @@
+# Definition of templates to be used when something went wrong
+parameters:
+    error.base_folder: %bbapp.base.dir%/Resources/layouts/error/
+    error.404: '404.phtml'
+    error.500: '500.phtml'
+    error.default: 'default.phtml'

--- a/Config/services/services.yml
+++ b/Config/services/services.yml
@@ -174,6 +174,10 @@ services:
         class: BackBee\Event\Listener\DoctrineListener
         arguments: [@bbapp]
 
+    exception.listener:
+        class: BackBee\Event\Listener\ExceptionListener
+        arguments: [@bbapp]
+
     controller_resolver:
         class:      %bbapp.controller_resolver.class%
         arguments:  [@bbapp]

--- a/Event/Listener/ExceptionListener.php
+++ b/Event/Listener/ExceptionListener.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee5 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Event\Listener;
+
+use BackBee\BBApplication;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @author Mickaël Andrieu <mickael.andrieu@lp-digital.fr>
+ */
+class ExceptionListener
+{
+    /**
+     * @var BackBee\Renderer
+     */
+    private $renderer;
+
+    /**
+     * @var Symfony\Component\HttpFoundation\Response
+     */
+    private $response;
+
+    public function __construct(BBApplication $application)
+    {
+        $this->application = $application;
+        $this->renderer = $application->getRenderer();
+        $this->response = new Response();
+    }
+
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+
+        $exception = $event->getException();
+        $statusCode = $exception->getStatusCode();
+
+        switch($statusCode) {
+            case 404:
+            case 500:
+                $parameterKey = "error.$statusCode";
+            break;
+            default:
+                $parameterKey = 'error.default';
+        }
+
+        $parameter = $this->application->getContainer()->getParameter($parameterKey);
+        $view = $this->getErrorTemplate($parameter);
+
+        $this->response
+            ->setContent($this->renderer->partial($view, ['error' => $exception]));
+
+        $event->setResponse($this->response);
+        $filterEvent = new FilterResponseEvent($event->getKernel(), $event->getRequest(), $event->getRequestType(), $event->getResponse());
+        $event->getDispatcher()->dispatch(KernelEvents::RESPONSE, $filterEvent);
+    }
+
+    /**
+     * Returns the path of the template for the selected http status code
+     * or default one.
+     *
+     * @input string $parameter path related to 404|500|default HTTP status code
+     *
+     * @return string
+     */
+    private function getErrorTemplate($parameter)
+    {
+        return $this->application
+            ->getContainer()
+            ->getParameter('error.base_folder')
+            . $parameter
+        ;
+    }
+}

--- a/FrontController/FrontController.php
+++ b/FrontController/FrontController.php
@@ -30,6 +30,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -203,7 +204,7 @@ class FrontController implements HttpKernelInterface
                 $matches = $urlMatcher->match($this->getRequest()->getPathInfo());
 
                 if (!isset($matches['_controller'])) {
-                    // set default cotnroller to this
+                    // set default controller to this
                     $matches['_controller'] = $this;
                 }
 
@@ -450,21 +451,6 @@ class FrontController implements HttpKernelInterface
             return;
         }
 
-        // if (null !== $this->getApplication()->getBBUserToken()) {
-        //     // Launch NestedNode jobs
-        //     $container = $this->getApplication()->getContainer();
-        //     if (true === ($container->hasParameter('bbapp.script.command') && $container->hasParameter('bbapp.console.command'))) {
-        //         $this->getApplication()->debug('Launching NestedNode jobs: '.sprintf('%s %s nestednode:jobs:process &', $container->getParameter('bbapp.script.command'), $container->getParameter('bbapp.console.command')));
-        //         $env = $this->getApplication()->getEnvironment();
-        //         if (true === empty($env)) {
-        //             $env = 'dev';
-        //         }
-        //         exec(sprintf('%s %s nestednode:jobs:process --env=%s &', $container->getParameter('bbapp.script.command'), $this->getApplication()->getBaseDir(). '/' . $container->getParameter('bbapp.console.command'), $env));
-        //     }
-        // }
-
-        // force content output
-//        @ini_set('zlib.output_compression', 0); // 2014-06-23: comment by c.rouillon
         ob_implicit_flush(true);
         flush();
 
@@ -596,55 +582,13 @@ class FrontController implements HttpKernelInterface
      * @param integer    $type    The type of the request
      *
      * @return Response A Response instance
-     *
-     * @throws \Exception
      */
-    private function handleException(\Exception $e, $request, $type)
+    private function handleException(\Exception $exception, Request $request, $type)
     {
-        $event = new GetResponseForExceptionEvent($this, $request, $type, $e);
+        $event = new GetResponseForExceptionEvent($this, $request, $type, $exception);
         $this->application->getEventDispatcher()->dispatch(KernelEvents::EXCEPTION, $event);
 
-        // a listener might have replaced the exception
-        $e = $event->getException();
-
-        try {
-            if (!$event->hasResponse()) {
-                throw $e;
-            }
-        } catch (\Exception $e) {
-            $response = new Response();
-
-            if ($e instanceof AccessDeniedException) {
-                $response->setStatusCode(403);
-                $response->setContent($e->getMessage());
-            } elseif ($e instanceof \InvalidArgumentException) {
-                $response->setStatusCode(500);
-                $response->setContent($e->getMessage());
-            } else {
-                throw $e;
-            }
-
-            return $response;
-        }
-
-        $response = $event->getResponse();
-
-        if (!$response->isClientError() && !$response->isServerError() && !$response->isRedirect()) {
-            // ensure that we actually have an error response
-            if ($e instanceof HttpExceptionInterface) {
-                // keep the HTTP status code and headers
-                $response->setStatusCode($e->getStatusCode());
-                $response->headers->add($e->getHeaders());
-            } elseif ($e instanceof FrontControllerException) {
-                // keep the HTTP status code
-                $response->setStatusCode($e->getStatusCode());
-            } else {
-                $response->setStatusCode(500);
-                $response->setContent($e->getMessage());
-            }
-        }
-
-        return $response;
+        return $event->getResponse();
     }
 
     /**

--- a/Resources/layouts/error/404.phtml
+++ b/Resources/layouts/error/404.phtml
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Erreur 404</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="<?php echo $this->getResourceUrl('css/style_reset.css'); ?>">
+</head>
+<body>
+    <!-- BB5 SITE WRAPPER -->
+    <div id="bb5-site-wrapper">
+        <!-- BEGIN bodywrapper: .container -->
+        <div class="container" id="body-wrapper">
+            <!-- bodywrapper -->
+            <div class="row" id="bb5-mainLayoutRow">
+                <div class="span12">
+                    <section role="main" class="section">
+                        <h1>Page non trouvée&hellip;</h1>
+                        <div class="announcement-wrapper">
+                            <p>Soit la page recherchée n'est pas activée, soit elle n'existe pas.</p>
+                        </div>
+                        <hr>
+                        <div class="announcement-box">
+                            <p>Veuillez nous excuser pour la gêne occasionnée.</p>
+                        </div>
+                    </section>
+                </div>
+            <!-- /end bodywrapper -->
+        </div>
+        <!-- END bodywrapper -->
+    </div>
+    <!-- END BB5 SITE WRAPPER -->
+</body>
+</html>

--- a/Resources/layouts/error/500.phtml
+++ b/Resources/layouts/error/500.phtml
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Erreur 500</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="<?php echo $this->getResourceUrl('css/style_reset.css'); ?>">
+</head>
+<body>
+    <!-- BB5 SITE WRAPPER -->
+    <div id="bb5-site-wrapper">
+        <!-- BEGIN bodywrapper: .container -->
+        <div class="container" id="body-wrapper">
+            <!-- bodywrapper -->
+            <div class="row" id="bb5-mainLayoutRow">
+                <div class="span12">
+                    <section role="main" class="section">
+                        <h1>Page non trouvée&hellip;</h1>
+                        <div class="announcement-wrapper">
+                            <p>Soit la page recherchée n'est pas activée, soit elle n'existe pas.</p>
+                        </div>
+                        <hr>
+                        <div class="announcement-box">
+                            <p>Veuillez nous excuser pour la gêne occasionnée.</p>
+                        </div>
+                    </section>
+                </div>
+            <!-- /end bodywrapper -->
+        </div>
+        <!-- END bodywrapper -->
+    </div>
+    <!-- END BB5 SITE WRAPPER -->
+</body>
+</html>


### PR DESCRIPTION
I moved the exception management to a ``kernel.exception`` listener.

Also, imo we should be able to override the error templates because our clients always want a customised error page, with their own content and dependencies.

This is an actual POC, but I need a review and advices to improve my commits.

Finally, how can I test it ?