### PR TITLE
[RFR] [Routing] fixed RouteCollection::getUri to return valid url (replacing '\' by '/')

### DIFF
--- a/Routing/RouteCollection.php
+++ b/Routing/RouteCollection.php
@@ -229,7 +229,7 @@ class RouteCollection extends sfRouteCollection implements DumpableServiceInterf
             $pathinfo .= $defaultExt;
         }
 
-        return $pathinfo;
+        return str_replace('\\', '/', $pathinfo);
     }
 
     /**


### PR DESCRIPTION
``BackBee\Routing\RouteCollection::getUri`` can return an invalid URL which contains ``\``, this PR brings fix that apply a ``str_replace`` to replace ``\`` by ``/``.