### PR TITLE
Fixed metadata() helper for twig

### DIFF
--- a/Renderer/Helper/metadata.php
+++ b/Renderer/Helper/metadata.php
@@ -46,7 +46,9 @@ class metadata extends AbstractHelper
             return '';
         }
 
-        if (null === $metadata = $page->getMetaData()) {
+        $metadata = $page->getMetadata();
+
+        if (null === $metadata || $metadata->count() === 0) {
             $metadata = new MetaDataBag($renderer->getApplication()->getConfig()->getMetadataConfig(), $page);
             $page->setMetaData($metadata);
             if ($renderer->getApplication()->getEntityManager()->contains($page)) {


### PR DESCRIPTION
Hi,

this follow the related issue on backbee standard: https://github.com/backbee/backbee-standard/issues/58 .

The SEO panel was correctly displayed but the metadata weren't written on HTML page. In my opinion, the API of Page object have been updated :)

I have updated the helper to make this work as expected. 