### PR TITLE
Closes #135 - fix debug panel displaying

### DIFF
--- a/Config/services/profiler.yml
+++ b/Config/services/profiler.yml
@@ -22,9 +22,8 @@ services:
         class:      Symfony\Component\HttpKernel\Profiler\Profiler
         arguments:  [@profiler.storage, @logging]
         calls:
-            - [set, [["@data_collector.config", "@data_collector.request", "@data_collector.exception", "@data_collector.events", "@data_collector.logger", "@data_collector.memory", "@data_collector.routing", @data_collector.doctrine]]]
-            #"@data_collector.time",
+            - [set, [["@data_collector.config", "@data_collector.request", "@data_collector.exception", "@data_collector.events", "@data_collector.logger", "@data_collector.memory", "@data_collector.routing", "@data_collector.doctrine"]]]
 
     profiler.storage:
         class:      BackBee\Profiler\FileProfilerStorage
-        arguments:  [@bbapp, "file:%bbapp.cache.dir%/_profiler/"]
+        arguments:  [@bbapp, "file:/%bbapp.cache.dir%/_profiler/"]

--- a/Config/services/services.yml
+++ b/Config/services/services.yml
@@ -49,7 +49,7 @@ parameters:
         exception: "%bbapp.base.dir%/Resources/scripts/Collector/exception.html.twig"
         events: "%bbapp.base.dir%/Resources/scripts/Collector/events.html.twig"
         logger: "%bbapp.base.dir%/Resources/scripts/Collector/logger.html.twig"
-#        time: "%bbapp.base.dir%/Resources/scripts/Collector/time.html.twig"
+        # time: "%bbapp.base.dir%/Resources/scripts/Collector/time.html.twig"
         memory: "%bbapp.base.dir%/Resources/scripts/Collector/memory.html.twig"
         routing: "%bbapp.base.dir%/Resources/scripts/Collector/routing.html.twig"
         db: "%bbapp.base.dir%/Resources/scripts/Collector/db.html.twig"

--- a/Logging/DebugStackLogger.php
+++ b/Logging/DebugStackLogger.php
@@ -111,5 +111,6 @@ class DebugStackLogger extends Logger implements DebugLoggerInterface
      */
     public function countErrors()
     {
+        return count($this->records);
     }
 }

--- a/Profiler/EventListener/ToolbarListener.php
+++ b/Profiler/EventListener/ToolbarListener.php
@@ -92,6 +92,7 @@ class ToolbarListener implements ContainerAwareInterface
 
         $profiler = $event->getKernel()->getApplication()->getContainer()->get('profiler');
         $profile = $profiler->collect($request, $response, null);
+        $profile->getCollector('logger')->lateCollect();
         $renderer = $event->getKernel()->getApplication()->getRenderer();
 
         $this->injectToolbar($response, $profile, $renderer);

--- a/Resources/scripts/Collector/logger.html.twig
+++ b/Resources/scripts/Collector/logger.html.twig
@@ -4,25 +4,25 @@
 {% block toolbar %}
         {% set icon %}
             <img width="15" height="28" alt="Logs" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAcCAYAAABoMT8aAAAA4klEQVQ4y2P4//8/AyWYYXgYwOPp6Xnc3t7+P7EYpB6k7+zZs2ADNEjRjIwDAgKWgAywIUfz8+fPVzg7O/8AGeCATQEQnAfi/SAah/wcV1dXvAYUgORANA75ehcXl+/4DHAABRIe+ZrhbgAhTHsDiEgHBA0glA6GfSDiw5mZma+A+sphBlhVVFQ88vHx+Xfu3Ll7QP5haOjjwtuAuGHv3r3NIMNABqh8+/atsaur666vr+9XUlwSHx//AGQANxCbAnEWyGQicRMQ9wBxIQM0qjiBWAFqkB00/glhayBWHwb1AgB38EJsUtxtWwAAAABJRU5ErkJggg==" />
-            {% if collector.counterrors %}
+            {% if collector.countErrors() %}
                 {% set status_color = "red" %}
             {% else %}
                 {% set status_color = "yellow" %}
             {% endif %}
-            {% set error_count = collector.counterrors + collector.countdeprecations %}
+            {% set error_count = collector.countErrors() + collector.countDeprecations() %}
             <span class="bb-toolbar-status bb-toolbar-status-{{ status_color }}">{{ error_count }}</span>
         {% endset %}
         {% set text %}
-            {% if collector.counterrors %}
+            {% if collector.countErrors() %}
                 <div class="bb-toolbar-item">
                     <b>Exception</b>
-                    <span class="bb-toolbar-status bb-toolbar-status-red">{{ collector.counterrors }}</span>
+                    <span class="bb-toolbar-status bb-toolbar-status-red">{{ collector.countErrors() }}</span>
                 </div>
             {% endif %}
-            {% if collector.countdeprecations %}
+            {% if collector.countDeprecations() %}
                 <div class="bb-toolbar-item">
                     <b>Deprecated Calls</b>
-                    <span class="bb-toolbar-status bb-toolbar-status-yellow">{{ collector.countdeprecations }}</span>
+                    <span class="bb-toolbar-status bb-toolbar-status-yellow">{{ collector.countDeprecations() }}</span>
                 </div>
             {% endif %}
         {% endset %}
@@ -32,7 +32,7 @@
 {% block panel %}
     <h2>Logs</h2>
 
-    {% if collector.logs %}
+    {% if collector.getLogs() %}
         {% import _self as logger %}
         <ol class="alt" id="bb-toolbar-log-items">
             {% for log in collector.logs if priority >= 0 and log.priority >= priority or priority < 0 and log.context.type|default(0) == priority %}


### PR DESCRIPTION
This closes https://github.com/backbee/backbee-standard/issues/135.

* Logs are now displayed
* Logs count are now displayed

I think for the future we need to think about use the Symfony's profiler instead of our own.

Time data collector remains inactive and should be part of another issue.

![logger_fixed](https://cloud.githubusercontent.com/assets/1247388/7416735/b69d92e6-ef61-11e4-9939-ff6a316b6930.png)


