### PR TITLE
[RFR] [NestedNode] fixed Page::setState to allow setting a root page to online and hidden state

### DIFF
--- a/NestedNode/Page.php
+++ b/NestedNode/Page.php
@@ -941,7 +941,7 @@ class Page extends AbstractNestedNode implements RenderableInterface, DomainObje
      */
     public function setState($state)
     {
-        if ($this->isRoot() && $state !== Page::STATE_ONLINE) {
+        if ($this->isRoot() && !($state & Page::STATE_ONLINE)) {
             throw new \LogicException("Root page state must be online.");
         }
 


### PR DESCRIPTION
PR #331 introduced an issue to installation of  ``backbee-standard`` cause we setted Root page to state 3 (= online and hidden) but the test inside ``BackBee\NestedNode\Page::setState`` throws exception if the page is not strictly equal to ``BackBee\NestedNode\Page::STATE_ONLINE``.