### PR TITLE
[RFR] [NestedNode] updated PageRepository's calls to Doctrine Paginator constructor

### DIFF
--- a/NestedNode/Repository/PageRepository.php
+++ b/NestedNode/Repository/PageRepository.php
@@ -372,7 +372,7 @@ class PageRepository extends NestedNodeRepository
           ->setMaxResults($maxresults)
         ;
 
-        return new Paginator($q);
+        return new Paginator($q, false);
     }
 
     /**
@@ -459,7 +459,7 @@ class PageRepository extends NestedNodeRepository
               ->setMaxResults($paging['limit'])
             ;
 
-            return new Paginator($q);
+            return new Paginator($q, false);
         }
 
         return $q->getQuery()->getResult();


### PR DESCRIPTION
As mentionned in #278, we must pass ``boolean false`` as second parameter of Doctrine Paginator constructor to to preserve the right collection items order.