### PR TITLE
[RFR] [ClassContent] [Workflow] fixed Doctrine mapping errors in AbstractClassContent and State #218

### DIFF
--- a/ClassContent/AbstractClassContent.php
+++ b/ClassContent/AbstractClassContent.php
@@ -95,7 +95,7 @@ abstract class AbstractClassContent extends AbstractContent
      *     inverseJoinColumns={@ORM\JoinColumn(name="content_uid", referencedColumnName="uid")}
      * )
      */
-    public $_subcontent;
+    protected $_subcontent;
 
     /**
      * The main nested node (page).

--- a/Workflow/State.php
+++ b/Workflow/State.php
@@ -90,7 +90,7 @@ class State extends AbstractObjectIdentifiable implements \JsonSerializable
      * The optional layout to be applied for state.
      *
      * @var \BackBee\Site\Layout
-     * @ORM\ManyToOne(targetEntity="BackBee\Site\Layout", fetch="EXTRA_LAZY")
+     * @ORM\ManyToOne(targetEntity="BackBee\Site\Layout", inversedBy="_states", fetch="EXTRA_LAZY")
      * @ORM\JoinColumn(name="layout", referencedColumnName="uid")
      */
     protected $_layout;


### PR DESCRIPTION
Changed visibility of ``BackBee\ClassContent\AbstractClassContent::$_subcontent`` attribute from ``public`` to ``protected`` otherwise it can break Doctrine lazy-load mechanism.

Added ``inversedBy`` property to ``BackBee\Workflow\State::$_layout`` attribute annotation.

More details on #218.