### PR TITLE
[Bundle] updated BundleLoader::addClassContentDir #164

### DIFF
--- a/Bundle/BundleLoader.php
+++ b/Bundle/BundleLoader.php
@@ -420,7 +420,7 @@ class BundleLoader
         } else {
             $directory = realpath(dirname($config->getBaseDir()).DIRECTORY_SEPARATOR.'ClassContent');
             if (false !== $directory) {
-                $this->application->pushClassContentDir($directory);
+                $this->application->unshiftClassContentDir($directory);
             }
         }
     }


### PR DESCRIPTION
Updated ``BackBee\Bundle\BundleLoader::addClassContentDir`` to use ``BackBee\BBApplication::unshiftClassContentDir`` instead of ``BackBee\BBApplication::unshiftClassContentDir`` to allow bundle to override ``backbee/backbee`` core classcontent yaml file.