### PR TITLE
[Rest] updated ClassContentController::deleteAction to call entity manager::flush()

### DIFF
--- a/ClassContent/Repository/ClassContentRepository.php
+++ b/ClassContent/Repository/ClassContentRepository.php
@@ -873,9 +873,9 @@ class ClassContentRepository extends EntityRepository
     public function deleteContent(AbstractClassContent $content, $mainContent = true)
     {
         $parents = $content->getParentContent();
-        $media = $this->_em->getRepository('BackBee\NestedNode\Media')->findOneBy(array(
+        $media = $this->_em->getRepository('BackBee\NestedNode\Media')->findOneBy([
             '_content' => $content->getUid(),
-        ));
+        ]);
 
         if (($parents->count() <= 1 && null === $media) || true === $mainContent) {
             foreach ($content->getData() as $element) {
@@ -894,12 +894,13 @@ class ClassContentRepository extends EntityRepository
 
             $this->_em->getConnection()->executeQuery(
                 'DELETE FROM indexation WHERE owner_uid = :uid',
-                array('uid' => $content->getUid())
+                ['uid' => $content->getUid()]
             )->execute();
             $this->_em->getConnection()->executeQuery(
                 'DELETE FROM revision WHERE content_uid = :uid',
-                array('uid' => $content->getUid())
+                ['uid' => $content->getUid()]
             )->execute();
+
             $this->_em->remove($content);
         }
     }

--- a/Rest/Controller/ClassContentController.php
+++ b/Rest/Controller/ClassContentController.php
@@ -278,6 +278,7 @@ class ClassContentController extends AbstractRestController
 
         try {
             $this->getEntityManager()->getRepository('BackBee\ClassContent\AbstractClassContent')->deleteContent($content);
+            $this->getEntityManager()->flush();
         } catch (\Exception $e) {
             throw new BadRequestHttpException("Unable to delete content with type: `$type` and uid: `$uid`");
         }


### PR DESCRIPTION
@hbaptiste, I just fixed your bug about classcontent REST API ``::deleteAction()`` that does not remove the content. This is caused by the fact that I forgot to call ``Doctrine\ORM\EntityManager::flush()`` method, my apologizes to you.