### PR TITLE
[ClassContent] added listener for 'nestednode.page.onflush' event #324

### DIFF
--- a/ClassContent/ClassContentManager.php
+++ b/ClassContent/ClassContentManager.php
@@ -191,7 +191,7 @@ class ClassContentManager
         return $classnames;
     }
 
-        /**
+    /**
      * Returns current revision for the given $content
      *
      * @param AbstractClassContent $content content we want to get the latest revision

--- a/Config/events.yml
+++ b/Config/events.yml
@@ -49,6 +49,7 @@ nestednode.page.onflush:
         - [BackBee\Event\Listener\MetaDataListener, onFlushPage]
         - [BackBee\Event\Listener\IndexationListener, onFlushPage]
         - [BackBee\Event\Listener\RewritingListener, onFlushPage]
+        - [BackBee\Event\Listener\ClassContentListener, onFlushPage]
         - [@cache.listener, onFlushPage]
 
 site.layout.prepersist:
@@ -66,11 +67,11 @@ site.layout.postremove:
 revision.postload:
     listeners:
         - [BackBee\Event\Listener\RevisionListener, onPostLoad]
-        
+
 revision.preflush:
     listeners:
         - [BackBee\Event\Listener\RevisionListener, onPreFlushElementFile]
-        
+
 element.keyword.render:
     listeners:
         - [BackBee\Event\Listener\elementListener, onRender]


### PR DESCRIPTION
Added ``BackBee\Event\Listener\ClassContentListener::onFlushPage`` to catch everytime we are persisting a new page event. We are looking for any default classcontent (when the main node is the current page)to create its draft. We also apply the same logic to the default content's subcontents.

This is useful to allow commit of default classcontent with ClassContent REST API.