### PR TITLE
Fix page duplication

### DIFF
--- a/Resources/layouts/error/default.phtml
+++ b/Resources/layouts/error/default.phtml
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="<?php echo $this->getResourceUrl('css/style_reset.css'); ?>">
 </head>
 <body>
-    <?php echo $this->bb5toolbar(); ?>
 
     <!-- BB5 SITE WRAPPER -->
     <div id="bb5-site-wrapper">

--- a/Rewriting/UrlGenerator.php
+++ b/Rewriting/UrlGenerator.php
@@ -279,8 +279,8 @@ class UrlGenerator implements UrlGeneratorInterface
             $existings = $this->application->getEntityManager()->getConnection()->executeQuery(
                 'SELECT uid FROM page WHERE `root_uid` = :root AND url REGEXP :regex',
                 array(
-                    'root'  => $page->getRoot()->getUid(),
                     'regex' => $url.'(-[0-9]+)?$',
+                    'root'  => $page->getRoot()->getUid(),
                 )
             )->fetchAll();
 


### PR DESCRIPTION
refs https://github.com/backbee/backbee-standard/issues/113

Duplication of a page doesn't generate a new url for the newly duplicated page.