### PR TITLE
[ClassContent] updated RevisionListener::onFlushElementFile

### DIFF
--- a/ClassContent/ClassContentManager.php
+++ b/ClassContent/ClassContentManager.php
@@ -71,7 +71,7 @@ class ClassContentManager
     }
 
     /**
-     * Updates the content which provided data.
+     * Updates the content whith provided data.
      *
      * @param  AbstractClassContent $content
      * @param  array         $data    array of data that must contains parameters and/or elements key

--- a/Config/events.yml
+++ b/Config/events.yml
@@ -68,9 +68,9 @@ revision.postload:
     listeners:
         - [BackBee\Event\Listener\RevisionListener, onPostLoad]
 
-revision.preflush:
+revision.onflush:
     listeners:
-        - [BackBee\Event\Listener\RevisionListener, onPreFlushElementFile]
+        - [BackBee\Event\Listener\RevisionListener, onFlushElementFile]
 
 element.keyword.render:
     listeners:

--- a/Event/Listener/RevisionListener.php
+++ b/Event/Listener/RevisionListener.php
@@ -111,26 +111,26 @@ class RevisionListener
         }
     }
 
-    public static function onPreFlushElementFile(Event $event)
+    public static function onFlushElementFile(Event $event)
     {
         $revision = $event->getTarget();
         $content = $revision->getContent();
-        
+
         if (!$content instanceof ElementFile) {
             return;
         }
-        
+
         $application = $event->getApplication();
         $em = $application->getEntityManager();
         $uow = $em->getUnitOfWork();
-        
+
         if ($uow->isScheduledForDelete($content)) {
             return;
         }
-        
+
         $fileRepository = $em->getRepository('BackBee\ClassContent\Element\File');
         $fileRepository->setDirectories($application);
-        
+
         $fileRepository->commitFile($content);
 
         $moveFrom = $content->path;
@@ -145,6 +145,8 @@ class RevisionListener
             $content->setParam('width', $width);
             $content->setParam('height', $height);
         }
+
+        $uow->recomputeSingleEntityChangeSet($em->getClassMetadata('BackBee\ClassContent\Revision'), $revision);
     }
 
     public static function onPostLoad(Event $event)


### PR DESCRIPTION
Updated ``BackBee\Event\Listener\RevisionListener::onFlushElementFile`` to listen ``revision.onflush`` instead of ``revision.preflush``.