### PR TITLE
[ClassContent] stop RevisionListener::onFlushElementFile execution if the file's path is not valid

### DIFF
--- a/Event/Listener/RevisionListener.php
+++ b/Event/Listener/RevisionListener.php
@@ -116,7 +116,7 @@ class RevisionListener
         $revision = $event->getTarget();
         $content = $revision->getContent();
 
-        if (!$content instanceof ElementFile) {
+        if (!($content instanceof ElementFile) || !is_file($content->path)) {
             return;
         }
 


### PR DESCRIPTION
The move of the file has to be done only in case that the file's path is valid, else it will throw an exception.