### PR TITLE
Added option to return isRoot() value of Page from REST api

### DIFF
--- a/NestedNode/AbstractNestedNode.php
+++ b/NestedNode/AbstractNestedNode.php
@@ -269,6 +269,10 @@ abstract class AbstractNestedNode extends AbstractObjectIdentifiable
      * Is the node is a root ?
      *
      * @return Boolean TRUE if the node is root of tree, FALSE otherwise
+     * /**
+     * @Serializer\VirtualProperty
+     * @Serializer\SerializedName("is_root")
+     *
      */
     public function isRoot()
     {

--- a/Rest/Controller/PageController.php
+++ b/Rest/Controller/PageController.php
@@ -461,7 +461,7 @@ class PageController extends AbstractRestController
                 '',
                 false
             ),
-            'url' => $page->getUrl()
+            'BB-PAGE-URL' => $page->getUrl()
         ]);
     }
 

--- a/Rest/Tests/Controller/PageControllerTest.php
+++ b/Rest/Tests/Controller/PageControllerTest.php
@@ -167,7 +167,7 @@ class PageControllerTest extends RestTestCase
         );
 
         $this->assertTrue($response->headers->has('location'));
-        $this->assertEquals('/a-new-title', $response->headers->get('url'));
+        $this->assertEquals('/a-new-title', $response->headers->get('BB-PAGE-URL'));
         $this->assertEquals(201, $response->getStatusCode());
     }
 


### PR DESCRIPTION
this pull request is needed by BbCoreJs to get the information about ``isRoot()`` of a Page.

refs: https://github.com/backbee/BbCoreJs/issues/439