### PR TITLE
Replaced reference to 'AClassContent' by 'AbstractClassContent'

### DIFF
--- a/CHANGELOG-1.0.md
+++ b/CHANGELOG-1.0.md
@@ -6,6 +6,6 @@ This changelog references the relevant changes (bug and security fixes) done in 
 
   * __BC #295 : Coding standard class naming convention refactor in Abstract / Interface / Exception
   * __BC #177 [ClassContent]__ Changed ``AContent::getParam`` and ``AContent::setParam`` API, we cannot anymore use them to set or get every parameters. To do so, use respectively ``AContent::setAllParams`` and ``AContent::getAllParams``.
-  * __BC #177 [ClassContent]__ Renamed method of AClassContent, from ``getDefaultParameters`` to ``getDefaultParams``.
+  * __BC #177 [ClassContent]__ Renamed method of AbstractClassContent, from ``getDefaultParameters`` to ``getDefaultParams``.
   * __BC #188 [Bundle]__ Renamed ``AbstractBaseBundle`` to ``AbstractBundle`` and removed ABundle, every bundle must extends ``AbstractBundle`` to be compatible with BackBee REST API
   * __feature #178 [Bundle] bundle's service identifier pattern and bundle's config service identifier pattern has changed__ (pattern changed from ``bundle.commentbundle`` to ``bundle.comment``, bundle's config service identifier still accessible by appending ``.config`` to bundle service identifier, which result to `bundle.comment.config``)

--- a/ClassContent/Indexation.php
+++ b/ClassContent/Indexation.php
@@ -32,8 +32,14 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @copyright   Lp digital system
  * @author      c.rouillon <charles.rouillon@lp-digital.fr>
+ *
  * @ORM\Entity(repositoryClass="BackBee\ClassContent\Repository\IndexationRepository")
- * @ORM\Table(name="indexation",indexes={@ORM\Index(name="IDX_OWNER", columns={"owner_uid"}), @ORM\Index(name="IDX_CONTENT", columns={"content_uid"}), @ORM\Index(name="IDX_VALUE", columns={"value"}), @ORM\Index(name="IDX_SEARCH", columns={"field", "value"})})
+ * @ORM\Table(name="indexation",indexes={
+ *     @ORM\Index(name="IDX_OWNER", columns={"owner_uid"}),
+ *     @ORM\Index(name="IDX_CONTENT", columns={"content_uid"}),
+ *     @ORM\Index(name="IDX_VALUE", columns={"value"}),
+ *     @ORM\Index(name="IDX_SEARCH", columns={"field", "value"})
+ * })
  */
 class Indexation
 {
@@ -41,6 +47,7 @@ class Indexation
      * The indexed content.
      *
      * @var string
+     *
      * @ORM\Id
      * @ORM\ManyToOne(targetEntity="BackBee\ClassContent\AbstractClassContent", inversedBy="_indexation", fetch="EXTRA_LAZY")
      * @ORM\JoinColumn(name="content_uid", referencedColumnName="uid")
@@ -51,6 +58,7 @@ class Indexation
      * The indexed field of the content.
      *
      * @var string
+     *
      * @ORM\Id
      * @ORM\Column(type="string", name="field")
      */
@@ -59,7 +67,8 @@ class Indexation
     /**
      * The owner content of the indexed field.
      *
-     * @var AClassContent
+     * @var AbstractClassContent
+     *
      * @ORM\ManyToOne(targetEntity="BackBee\ClassContent\AbstractClassContent", fetch="EXTRA_LAZY")
      * @ORM\JoinColumn(name="owner_uid", referencedColumnName="uid")
      */
@@ -69,6 +78,7 @@ class Indexation
      * The value of the indexed field.
      *
      * @var string
+     *
      * @ORM\Column(type="string", name="value")
      */
     protected $_value;
@@ -77,6 +87,7 @@ class Indexation
      * The optional callback to apply while indexing.
      *
      * @var string
+     *
      * @ORM\Column(type="string", name="callback", nullable=true)
      */
     protected $_callback;
@@ -92,11 +103,13 @@ class Indexation
      */
     public function __construct($content = null, $field = null, $owner = null, $value = null, $callback = null)
     {
-        $this->setContent($content)
-                ->setField($field)
-                ->setOwner($owner)
-                ->setValue($value)
-                ->setCallback($callback);
+        $this
+            ->setContent($content)
+            ->setField($field)
+            ->setOwner($owner)
+            ->setValue($value)
+            ->setCallback($callback)
+        ;
     }
 
     /**
@@ -144,7 +157,7 @@ class Indexation
      *
      * @param string $content
      *
-     * @return \BackBee\ClassContent\Indexation
+     * @return self
      */
     public function setContent($content)
     {
@@ -158,7 +171,7 @@ class Indexation
      *
      * @param string $field
      *
-     * @return \BackBee\ClassContent\Indexation
+     * @return self
      */
     public function setField($field)
     {
@@ -172,7 +185,7 @@ class Indexation
      *
      * @param \Symfony\Component\Security\Acl\Model\SecurityIdentityInterface $owner
      *
-     * @return \BackBee\ClassContent\Indexation
+     * @return self
      */
     public function setOwner($owner)
     {
@@ -186,7 +199,7 @@ class Indexation
      *
      * @param string $value
      *
-     * @return \BackBee\ClassContent\Indexation
+     * @return self
      */
     public function setValue($value)
     {
@@ -200,7 +213,7 @@ class Indexation
      *
      * @param function $callback
      *
-     * @return \BackBee\ClassContent\Indexation
+     * @return self
      */
     public function setCallback($callback)
     {

--- a/ClassContent/Revision.php
+++ b/ClassContent/Revision.php
@@ -52,8 +52,13 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @copyright   Lp digital system
  * @author      c.rouillon <charles.rouillon@lp-digital.fr>
+ *
  * @ORM\Entity(repositoryClass="BackBee\ClassContent\Repository\RevisionRepository")
- * @ORM\Table(name="revision", indexes={@ORM\Index(name="IDX_CONTENT", columns={"content_uid"}), @ORM\Index(name="IDX_REVISION_CLASSNAME_1", columns={"classname"}), @ORM\Index(name="IDX_DRAFT", columns={"owner", "state"})})
+ * @ORM\Table(name="revision", indexes={
+ *     @ORM\Index(name="IDX_CONTENT", columns={"content_uid"}),
+ *     @ORM\Index(name="IDX_REVISION_CLASSNAME_1", columns={"classname"}),
+ *     @ORM\Index(name="IDX_DRAFT", columns={"owner", "state"})
+ * })
  * @ORM\HasLifecycleCallbacks
  */
 class Revision extends AbstractContent implements \Iterator, \Countable
@@ -103,7 +108,8 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     /**
      * The attached revisionned content.
      *
-     * @var \BackBee\ClassContent\AClassContent
+     * @var AbstractClassContent
+     *
      * @ORM\ManyToOne(targetEntity="BackBee\ClassContent\AbstractClassContent", inversedBy="_revisions", fetch="EXTRA_LAZY")
      * @ORM\JoinColumn(name="content_uid", referencedColumnName="uid")
      */
@@ -113,6 +119,7 @@ class Revision extends AbstractContent implements \Iterator, \Countable
      * The entity target content classname.
      *
      * @var string
+     *
      * @ORM\Column(type="string", name="classname")
      */
     private $_classname;
@@ -120,7 +127,8 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     /**
      * The owner of this revision.
      *
-     * @var \Symfony\Component\Security\Acl\Domain\UserSecurityIdentity
+     * @var UserSecurityIdentity
+     *
      * @ORM\Column(type="string", name="owner")
      */
     private $_owner;
@@ -146,7 +154,7 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     private $em;
 
     /**
-     * @var \BackBee\Security\Token\BBUserToken
+     * @var BBUserToken
      */
     private $token;
 
@@ -176,7 +184,7 @@ class Revision extends AbstractContent implements \Iterator, \Countable
      *
      * @param \Doctrine\ORM\EntityManager $em
      *
-     * @return \BackBee\ClassContent\Revision
+     * @return Revision
      */
     public function setEntityManager(EntityManager $em = null)
     {
@@ -188,9 +196,9 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     /**
      * Sets the current BB user's token to dynamically load subrevisions.
      *
-     * @param \BackBee\Security\Token\BBUserToken $token
+     * @param  BBUserToken $token
      *
-     * @return \BackBee\ClassContent\Revision
+     * @return Revision
      */
     public function setToken(BBUserToken $token = null)
     {
@@ -202,7 +210,7 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     /**
      * Returns the revisionned content.
      *
-     * @return \BackBee\ClassContent\AbstractClassContent
+     * @return AbstractClassContent
      * @codeCoverageIgnore
      */
     public function getContent()
@@ -224,7 +232,7 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     /**
      * Returns the owner of the revision.
      *
-     * @return \Symfony\Component\Security\Acl\Domain\UserSecurityIdentity
+     * @return UserSecurityIdentity
      * @codeCoverageIgnore
      */
     public function getOwner()
@@ -248,7 +256,7 @@ class Revision extends AbstractContent implements \Iterator, \Countable
      *
      * @param array $data
      *
-     * @return \BackBee\ClassContent\AbstractClassContent the current instance content
+     * @return AbstractClassContent the current instance content
      * @codeCoverageIgnore
      */
     public function setData(array $data)
@@ -261,9 +269,9 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     /**
      * Sets the attached revisionned content.
      *
-     * @param \BackBee\ClassContent\AClassContent $content
+     * @param  AbstractClassContent $content
      *
-     * @return \BackBee\ClassContent\AbstractClassContent the current instance content
+     * @return AbstractClassContent the current instance content
      */
     public function setContent(AbstractClassContent $content = null)
     {
@@ -281,7 +289,7 @@ class Revision extends AbstractContent implements \Iterator, \Countable
      *
      * @param string $classname
      *
-     * @return \BackBee\ClassContent\AbstractClassContent the current instance content
+     * @return AbstractClassContent the current instance content
      * @codeCoverageIgnore
      */
     public function setClassname($classname)
@@ -294,9 +302,9 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     /**
      * Sets the owner of the revision.
      *
-     * @param \Symfony\Component\Security\Core\User\UserInterface $user
+     * @param  UserInterface $user
      *
-     * @return \BackBee\ClassContent\AbstractClassContent                 the current instance content
+     * @return AbstractClassContent the current instance content
      * @codeCoverageIgnore
      */
     public function setOwner(UserInterface $user)
@@ -311,7 +319,7 @@ class Revision extends AbstractContent implements \Iterator, \Countable
      *
      * @param string $comment
      *
-     * @return \BackBee\ClassContent\AbstractClassContent the current instance content
+     * @return AbstractClassContent the current instance content
      * @codeCoverageIgnore
      */
     public function setComment($comment)
@@ -329,7 +337,10 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     public function clear()
     {
         if (!($this->_content instanceof ContentSet)) {
-            throw new ClassContentException(sprintf('Can not clear an content %s.', get_class($this)), ClassContentException::UNKNOWN_ERROR);
+            throw new ClassContentException(
+                sprintf('Can not clear an content %s.', get_class($this)),
+                ClassContentException::UNKNOWN_ERROR
+            );
         }
 
         $this->_data = array();
@@ -344,7 +355,10 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     public function count()
     {
         if (!($this->_content instanceof ContentSet)) {
-            throw new ClassContentException(sprintf('Can not count an content %s.', get_class($this)), ClassContentException::UNKNOWN_ERROR);
+            throw new ClassContentException(
+                sprintf('Can not count an content %s.', get_class($this)),
+                ClassContentException::UNKNOWN_ERROR
+            );
         }
 
         return count($this->_data);
@@ -358,7 +372,10 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     public function current()
     {
         if (!($this->_content instanceof ContentSet)) {
-            throw new ClassContentException(sprintf('Can not get current of a content %s.', get_class($this)), ClassContentException::UNKNOWN_ERROR);
+            throw new ClassContentException(
+                sprintf('Can not get current of a content %s.', get_class($this)),
+                ClassContentException::UNKNOWN_ERROR
+            );
         }
 
         return $this->getData($this->_index);
@@ -386,7 +403,10 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     public function item($index)
     {
         if (!($this->_content instanceof ContentSet)) {
-            throw new ClassContentException(sprintf('Can not get item of a content %s.', get_class($this)), ClassContentException::UNKNOWN_ERROR);
+            throw new ClassContentException(
+                sprintf('Can not get item of a content %s.', get_class($this)),
+                ClassContentException::UNKNOWN_ERROR
+            );
         }
 
         if (0 <= $index && $index < $this->count()) {
@@ -404,7 +424,10 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     public function key()
     {
         if (!($this->_content instanceof ContentSet)) {
-            throw new ClassContentException(sprintf('Can not get key of a content %s.', get_class($this)), ClassContentException::UNKNOWN_ERROR);
+            throw new ClassContentException(
+                sprintf('Can not get key of a content %s.', get_class($this)),
+                ClassContentException::UNKNOWN_ERROR
+            );
         }
 
         return $this->_index;
@@ -428,7 +451,10 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     public function next()
     {
         if (!($this->_content instanceof ContentSet)) {
-            throw new ClassContentException(sprintf('Can not get next of a content %s.', get_class($this)), ClassContentException::UNKNOWN_ERROR);
+            throw new ClassContentException(
+                sprintf('Can not get next of a content %s.', get_class($this)),
+                ClassContentException::UNKNOWN_ERROR
+            );
         }
 
         return $this->getData($this->_index++);
@@ -464,7 +490,10 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     public function push(AbstractClassContent $var)
     {
         if (!($this->_content instanceof ContentSet)) {
-            throw new ClassContentException(sprintf('Can not push in a content %s.', get_class($this)), ClassContentException::UNKNOWN_ERROR);
+            throw new ClassContentException(
+                sprintf('Can not push in a content %s.', get_class($this)),
+                ClassContentException::UNKNOWN_ERROR
+            );
         }
 
         if ($this->isAccepted($var)) {
@@ -482,7 +511,10 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     public function rewind()
     {
         if (!($this->_content instanceof ContentSet)) {
-            throw new ClassContentException(sprintf('Can not rewind a content %s.', get_class($this)), ClassContentException::UNKNOWN_ERROR);
+            throw new ClassContentException(
+                sprintf('Can not rewind a content %s.', get_class($this)),
+                ClassContentException::UNKNOWN_ERROR
+            );
         }
 
         $this->_index = 0;
@@ -532,7 +564,10 @@ class Revision extends AbstractContent implements \Iterator, \Countable
     public function valid()
     {
         if (!($this->_content instanceof ContentSet)) {
-            throw new ClassContentException(sprintf('Can not valid a content %s.', get_class($this)), ClassContentException::UNKNOWN_ERROR);
+            throw new ClassContentException(
+                sprintf('Can not valid a content %s.', get_class($this)),
+                ClassContentException::UNKNOWN_ERROR
+            );
         }
 
         return isset($this->_data[$this->_index]);

--- a/Event/Listener/ClassContentListener.php
+++ b/Event/Listener/ClassContentListener.php
@@ -137,12 +137,23 @@ class ClassContentListener
     {
         $content = $event->getTarget();
         if (!($content instanceof AbstractClassContent)) {
-            throw new BBException('Enable to update object', BBException::INVALID_ARGUMENT, new \InvalidArgumentException(sprintf('Only BackBee\ClassContent\AClassContent can be commit, `%s` received', get_class($content))));
+            throw new BBException(
+                'Enable to update object',
+                BBException::INVALID_ARGUMENT,
+                new \InvalidArgumentException(sprintf(
+                    'Only BackBee\ClassContent\AbstractClassContent can be commit, `%s` received',
+                    get_class($content)
+                ))
+            );
         }
 
         $dispatcher = $event->getDispatcher();
         if (null === $application = $dispatcher->getApplication()) {
-            throw new BBException('Enable to update object', BBException::MISSING_APPLICATION, new \RuntimeException('BackBee application has to be initialized'));
+            throw new BBException(
+                'Enable to update object',
+                BBException::MISSING_APPLICATION,
+                new \RuntimeException('BackBee application has to be initialized')
+            );
         }
 
         if (null === $token = $application->getBBUserToken()) {
@@ -162,9 +173,16 @@ class ClassContentListener
             throw new ClassContentException('Content is up to date', ClassContentException::REVISION_UPTODATE);
         }
 
-        $lastCommitted = $em->getRepository('BackBee\ClassContent\Revision')->findBy(array('_content' => $content, '_revision' => $content->getRevision(), '_state' => Revision::STATE_COMMITTED));
+        $lastCommitted = $em->getRepository('BackBee\ClassContent\Revision')->findBy([
+            '_content'  => $content,
+            '_revision' => $content->getRevision(),
+            '_state'    => Revision::STATE_COMMITTED,
+        ]);
         if (null === $lastCommitted) {
-            throw new ClassContentException('Enable to get last committed revision', ClassContentException::REVISION_MISSING);
+            throw new ClassContentException(
+                'Enable to get last committed revision',
+                ClassContentException::REVISION_MISSING
+            );
         }
 
         $content->updateDraft($lastCommitted);

--- a/Event/Listener/IndexationListener.php
+++ b/Event/Listener/IndexationListener.php
@@ -76,7 +76,7 @@ class IndexationListener implements EventSubscriberInterface
     private static $_site_content_done = array();
 
     /**
-     * Updates the site-content indexes for the scheduled AClassContent.
+     * Updates the site-content indexes for the scheduled AbstractClassContent.
      *
      * @param array $contents_inserted
      * @param array $contents_removed
@@ -95,7 +95,7 @@ class IndexationListener implements EventSubscriberInterface
     }
 
     /**
-     * Updates the content-content indexes for the scheduled AClassContent.
+     * Updates the content-content indexes for the scheduled AbstractClassContent.
      *
      * @param array $contents_saved
      * @param array $contents_removed

--- a/MetaData/MetaData.php
+++ b/MetaData/MetaData.php
@@ -217,7 +217,7 @@ class MetaData implements \IteratorAggregate, \Countable, \JsonSerializable
     }
 
     /**
-     * Compute values of attributes according to the AClassContent provided.
+     * Compute values of attributes according to the AbstractClassContent provided.
      *
      * @param  \BackBee\ClassContent\AbstractClassContent $content
      *

--- a/NestedNode/KeyWord.php
+++ b/NestedNode/KeyWord.php
@@ -111,7 +111,7 @@ class KeyWord extends AbstractNestedNode implements RenderableInterface
     protected $_children;
 
     /**
-     * A collection of AClassContent indexed by this keyword.
+     * A collection of AbstractClassContent indexed by this keyword.
      *
      * @ORM\ManyToMany(targetEntity="BackBee\ClassContent\AbstractClassContent", fetch="EXTRA_LAZY")
      * @ORM\JoinTable(name="keywords_contents",

--- a/NestedNode/Media.php
+++ b/NestedNode/Media.php
@@ -45,6 +45,7 @@ class Media implements \JsonSerializable
      * Unique identifier of the media.
      *
      * @var integer
+     *
      * @ORM\Id
      * @ORM\Column(type="integer", name="id")
      * @ORM\GeneratedValue(strategy="IDENTITY")
@@ -54,7 +55,8 @@ class Media implements \JsonSerializable
     /**
      * The media folder owning this media.
      *
-     * @var \BackBee\NestedNode\MediaFolder
+     * @var MediaFolder
+     *
      * @ORM\ManyToOne(targetEntity="BackBee\NestedNode\MediaFolder", inversedBy="_medias", cascade={"persist"}, fetch="EXTRA_LAZY")
      * @ORM\JoinColumn(name="media_folder_uid", referencedColumnName="uid")
      */
@@ -63,7 +65,8 @@ class Media implements \JsonSerializable
     /**
      * The element content of this media.
      *
-     * @var \BackBee\ClassContent\AClassContent
+     * @var AbstractClassContent
+     *
      * @ORM\ManyToOne(targetEntity="BackBee\ClassContent\AbstractClassContent", cascade={"persist"}, fetch="EXTRA_LAZY")
      * @ORM\JoinColumn(name="content_uid", referencedColumnName="uid")
      */
@@ -73,6 +76,7 @@ class Media implements \JsonSerializable
      * The title of this media.
      *
      * @var string
+     *
      * @ORM\Column(type="string", name="title")
      */
     protected $_title;
@@ -81,6 +85,7 @@ class Media implements \JsonSerializable
      * The publication datetime.
      *
      * @var \DateTime
+     *
      * @ORM\Column(type="datetime", name="date")
      */
     protected $_date;
@@ -89,6 +94,7 @@ class Media implements \JsonSerializable
      * The creation datetime.
      *
      * @var \DateTime
+     *
      * @ORM\Column(type="datetime", name="created")
      */
     protected $_created;
@@ -97,6 +103,7 @@ class Media implements \JsonSerializable
      * The last modification datetime.
      *
      * @var \DateTime
+     *
      * @ORM\Column(type="datetime", name="modified")
      */
     protected $_modified;

--- a/Security/Authorization/Voter/BBAclVoter.php
+++ b/Security/Authorization/Voter/BBAclVoter.php
@@ -140,7 +140,7 @@ class BBAclVoter extends AclVoter
     }
 
     /**
-     * Returns the vote for class content object, recursively till AClassContent.
+     * Returns the vote for class content object, recursively till AbstractClassContent.
      *
      * @param \Symfony\Component\Security\Core\Authentication\Token\TokenInterface $token
      * @param  \BackBee\ClassContent\AbstractClassContent $content


### PR DESCRIPTION
Some references to ``BackBee\ClassContent\AClassContent`` still remain so I cleaned it. Also Updated some classes coding style.