### PR TITLE
[ClassContent] AbstractContent::jsonSerialize also return extra parameter

### DIFF
--- a/ClassContent/AbstractContent.php
+++ b/ClassContent/AbstractContent.php
@@ -1031,6 +1031,7 @@ abstract class AbstractContent implements ObjectIdentifiableInterface, Renderabl
             'minentry'   => $this->getMinEntry(),
             'maxentry'   => $this->getMaxEntry(),
             'elements'   => $this->computeElementsToJson($this->getData()),
+            'extra'      => [],
         ];
 
         if (0 === count($data['parameters'])) {
@@ -1086,7 +1087,7 @@ abstract class AbstractContent implements ObjectIdentifiableInterface, Renderabl
         }
 
         if (self::JSON_DEFINITION_FORMAT === $format || self::JSON_INFO_FORMAT === $format) {
-            unset($data['elements']);
+            unset($data['elements'], $data['extra']);
         }
 
         if (self::JSON_DEFINITION_FORMAT === $format) {

--- a/ClassContent/Element/File.yml
+++ b/ClassContent/Element/File.yml
@@ -1,5 +1,6 @@
 File:
   repository: \BackBee\ClassContent\Repository\Element\FileRepository
+  traits: [BackBee\ClassContent\Traits\Element\FileJsonSerializeTrait]
   properties:
     name: File
     description: An attached file

--- a/ClassContent/Element/Image.yml
+++ b/ClassContent/Element/Image.yml
@@ -1,6 +1,7 @@
 Image:
   extends: \BackBee\ClassContent\Element\File
   repository: \BackBee\ClassContent\Repository\Element\ImageRepository
+  traits: [BackBee\ClassContent\Traits\Element\ImageJsonSerializeTrait]
   properties:
     name: Image
     description: An inline image

--- a/ClassContent/Tests/ClassContentTest.php
+++ b/ClassContent/Tests/ClassContentTest.php
@@ -237,6 +237,7 @@ class ClassContentTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(isset($data['elements']));
         $this->assertTrue(isset($data['properties']));
         $this->assertTrue(isset($data['image']));
+        $this->assertTrue(isset($data['extra']));
 
         $this->assertTrue(is_array($data['elements']));
 
@@ -271,6 +272,7 @@ class ClassContentTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(isset($data['modified']));
         $this->assertFalse(isset($data['revision']));
         $this->assertFalse(isset($data['elements']));
+        $this->assertFalse(isset($data['extra']));
         $this->assertFalse(isset($data['uid']));
 
         $this->assertEquals($this->content->getDefaultImageName(), $data['image']);
@@ -286,6 +288,7 @@ class ClassContentTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(isset($data['parameters']));
         $this->assertTrue(isset($data['elements']));
         $this->assertTrue(isset($data['image']));
+        $this->assertTrue(isset($data['extra']));
 
         $this->assertFalse(isset($data['state']));
         $this->assertFalse(isset($data['accept']));
@@ -318,5 +321,6 @@ class ClassContentTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(isset($data['minentry']));
         $this->assertFalse(isset($data['maxentry']));
         $this->assertFalse(isset($data['properties']));
+        $this->assertFalse(isset($data['extra']));
     }
 }

--- a/ClassContent/Traits/Element/FileJsonSerializeTrait.php
+++ b/ClassContent/Traits/Element/FileJsonSerializeTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace BackBee\ClassContent\Traits\Element;
+
+use BackBee\ClassContent\AbstractContent;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ */
+trait FileJsonSerializeTrait
+{
+    /**
+     * @see AbstractContent::jsonSerialize
+     */
+    public function jsonSerialize($format = AbstractContent::JSON_DEFAULT_FORMAT)
+    {
+        $data = parent::jsonSerialize($format);
+
+        if (AbstractContent::JSON_DEFAULT_FORMAT === $format || AbstractContent::JSON_CONCISE_FORMAT === $format) {
+            $data['extra']['file_size'] = null;
+            if (null !== $stat = $this->getParamValue('stat')) {
+                $stat = json_decode($stat, true);
+                if (is_array($stat) && isset($stat['size'])) {
+                    $data['extra']['file_size'] = $stat['size'];
+                }
+            }
+        }
+
+        return $data;
+    }
+}

--- a/ClassContent/Traits/Element/ImageJsonSerializeTrait.php
+++ b/ClassContent/Traits/Element/ImageJsonSerializeTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BackBee\ClassContent\Traits\Element;
+
+use BackBee\ClassContent\AbstractContent;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ */
+trait ImageJsonSerializeTrait
+{
+    /**
+     * @see AbstractContent::jsonSerialize
+     */
+    public function jsonSerialize($format = AbstractContent::JSON_DEFAULT_FORMAT)
+    {
+        $data = parent::jsonSerialize($format);
+
+        if (AbstractContent::JSON_DEFAULT_FORMAT === $format || AbstractContent::JSON_CONCISE_FORMAT === $format) {
+            $data['extra']['image_width'] = $this->getParamValue('width');
+            $data['extra']['image_height'] = $this->getParamValue('height');
+        }
+
+        return $data;
+    }
+}

--- a/NestedNode/Media.php
+++ b/NestedNode/Media.php
@@ -321,17 +321,20 @@ class Media implements \JsonSerializable
 
     public function jsonSerialize()
     {
-        $result = array();
+        $result = [];
         $result['id'] = $this->getId();
-        $result['uid'] = $this->getId();
         $result['image'] = $this->getContent() ? $this->getContent()->getImageName() : null;
-        $result['content_uid'] = $this->getContent()->getUid();
-        $result['mediaFolder'] = $this->getMediaFolder()->getUid();
+        $result['media_folder'] = $this->getMediaFolder()->getUid();
         $result['title'] = $this->getTitle();
-        $contentInfos = array();
-        $contentInfos["uid"] =  $this->getContent()->getUid();
-        $contentInfos["type"] = $this->getContent()->getContentType();
-        $result ["content"] = $contentInfos;
+
+        $contentData = $this->getContent() ? $this->getContent()->jsonSerialize() : [];
+
+        $result ['content'] = [
+            'uid'   => $this->getContent()->getUid(),
+            'type'  => $this->getContent()->getContentType(),
+            'extra' => isset($contentData['extra']) ? $contentData['extra'] : [],
+        ];
+
         return $result;
     }
 


### PR DESCRIPTION
This PR aims to resolve [backbee/bb-core-js issue #414](https://github.com/backbee/BbCoreJs/issues/414).

Updated ``BackBee\ClassContent\AbstractContent::jsonSerialize`` to also return extra parameters. Added ``BackBee\ClassContent\Traits\Element\FileJsonSerializeTrait`` and ``BackBee\ClassContent\Traits\Element\ImageJsonSerializeTrait`` to ``file_size``, ``image_width`` and ``image_height`` extra parameters.