### PR TITLE
[ClassContent] moved ClassContent listeners and removed unused methods #347

### DIFF
--- a/ClassContent/Listener/ClassContentListener.php
+++ b/ClassContent/Listener/ClassContentListener.php
@@ -21,7 +21,7 @@
  * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
  */
 
-namespace BackBee\Event\Listener;
+namespace BackBee\ClassContent\Listener;
 
 use BackBee\ClassContent\AbstractClassContent;
 use BackBee\ClassContent\Element\File as ElementFile;
@@ -214,21 +214,6 @@ class ClassContentListener
     }
 
     /**
-     * Occure on services.local.classcontent.postcall.
-     *
-     * @param \BackBee\Event\Event $event
-     */
-    public static function onServicePostCall(Event $event)
-    {
-        $service = $event->getTarget();
-        if (false === is_a($service, 'BackBee\Services\Local\ClassContent')) {
-            return;
-        }
-
-        self::setRendermodeParameter($event);
-    }
-
-    /**
      * Occurs on nestednode.page.onflush event.
      *
      * @param  Event  $event
@@ -260,57 +245,5 @@ class ClassContentListener
                 }
             }
         }
-    }
-
-    /**
-     * Dynamically add render modes options to the class.
-     *
-     * @param \BackBee\Event\Event $event
-     */
-    private static function setRendermodeParameter(Event $event)
-    {
-        $application = $event->getDispatcher()->getApplication();
-        if (null === $application) {
-            return;
-        }
-
-        $method = $event->getArgument('method');
-        if ('getContentParameters' !== $method) {
-            return;
-        }
-
-        $result = $event->getArgument('result', array());
-        if (!array_key_exists('rendermode', $result)) {
-            return;
-        }
-        if (!array_key_exists('array', $result['rendermode'])) {
-            return;
-        }
-        if (!array_key_exists('options', $result['rendermode']['array'])) {
-            return;
-        }
-
-        $params = $event->getArgument('params', array());
-        if (!array_key_exists('nodeInfos', $params)) {
-            return;
-        }
-        if (!array_key_exists('type', $params['nodeInfos'])) {
-            return;
-        }
-
-        $classname = '\BackBee\ClassContent\\'.$params['nodeInfos']['type'];
-        if (!class_exists($classname)) {
-            return;
-        }
-
-        $renderer = $application->getRenderer();
-        $modes = array('default' => 'default');
-        foreach ($renderer->getAvailableRenderMode(new $classname()) as $mode) {
-            $modes[$mode] = $mode;
-        }
-
-        $result['rendermode']['array']['options'] = $modes;
-
-        $event->setArgument('result', $result);
     }
 }

--- a/Config/events.yml
+++ b/Config/events.yml
@@ -1,27 +1,27 @@
 classcontent.include:
     listeners:
-        - [BackBee\Event\Listener\ClassContentListener, onInclude]
+        - [BackBee\ClassContent\Listener\ClassContentListener, onInclude]
 
 classcontent.update:
     listeners:
-        - [BackBee\Event\Listener\ClassContentListener, onUpdate]
+        - [BackBee\ClassContent\Listener\ClassContentListener, onUpdate]
 
 classcontent.onflush:
     listeners:
-        - [BackBee\Event\Listener\ClassContentListener, onFlushContent]
-        - [BackBee\Event\Listener\RevisionListener, onFlushContent]
-        - [BackBee\Event\Listener\IndexationListener, onFlushContent]
+        - [BackBee\ClassContent\Listener\ClassContentListener, onFlushContent]
+        - [BackBee\ClassContent\Listener\RevisionListener, onFlushContent]
+        - [BackBee\ClassContent\Listener\IndexationListener, onFlushContent]
         - [@cache.listener, onFlushContent]
         - [BackBee\Event\Listener\MetaDataListener, onFlushContent]
         - [BackBee\Event\Listener\RewritingListener, onFlushContent]
 
 classcontent.preremove:
     listeners:
-        - [BackBee\Event\Listener\ClassContentListener, onPreRemove]
+        - [BackBee\ClassContent\Listener\ClassContentListener, onPreRemove]
 
 classcontent.prerender:
     listeners:
-        - [BackBee\Event\Listener\RevisionListener, onPrerenderContent]
+        - [BackBee\ClassContent\Listener\RevisionListener, onPrerenderContent]
         - [@cache.listener, onPreRenderContent]
 
 classcontent.postrender:
@@ -30,7 +30,7 @@ classcontent.postrender:
 
 element.file.postremove:
     listeners:
-        - [BackBee\Event\Listener\ClassContentListener, onRemoveElementFile]
+        - [BackBee\ClassContent\Listener\ClassContentListener, onRemoveElementFile]
 
 nestednode.page.prerender:
     listeners:
@@ -47,9 +47,9 @@ nestednode.page.postrender:
 nestednode.page.onflush:
     listeners:
         - [BackBee\Event\Listener\MetaDataListener, onFlushPage]
-        - [BackBee\Event\Listener\IndexationListener, onFlushPage]
+        - [BackBee\ClassContent\Listener\IndexationListener, onFlushPage]
         - [BackBee\Event\Listener\RewritingListener, onFlushPage]
-        - [BackBee\Event\Listener\ClassContentListener, onFlushPage]
+        - [BackBee\ClassContent\Listener\ClassContentListener, onFlushPage]
         - [@cache.listener, onFlushPage]
 
 site.layout.prepersist:
@@ -66,11 +66,11 @@ site.layout.postremove:
 
 revision.postload:
     listeners:
-        - [BackBee\Event\Listener\RevisionListener, onPostLoad]
+        - [BackBee\ClassContent\Listener\RevisionListener, onPostLoad]
 
 revision.onflush:
     listeners:
-        - [BackBee\Event\Listener\RevisionListener, onFlushElementFile]
+        - [BackBee\ClassContent\Listener\RevisionListener, onFlushElementFile]
 
 element.keyword.render:
     listeners:


### PR DESCRIPTION
Moved ClassContent listeners from Event component into ClassContent component and removed unused methods inside them. It's mainly listeners that listened to JsonRPC server events. Also see #347.