### PR TITLE
[ClassContent] updated ClassContentManager::prepareDraftForCommit

### DIFF
--- a/ClassContent/ClassContentManager.php
+++ b/ClassContent/ClassContentManager.php
@@ -423,7 +423,7 @@ class ClassContentManager
                     $draft->push($element);
                 }
             }
-        } else {
+        } elseif (AbstractClassContent::STATE_NORMAL === $content->getState()) {
             foreach ($content->getData() as $key => $element) {
                 if (!isset($data['elements']) || !in_array($key, $data['elements'])) {
                     $draft->$key = $content->$key;

--- a/Rest/Controller/MediaController.php
+++ b/Rest/Controller/MediaController.php
@@ -101,7 +101,6 @@ class MediaController extends AbstractRestController
      */
     public function deleteAction($id)
     {
-
         if (null === $media = $this->getMediaRepository()->find($id)) {
             throw new NotFoundHttpException(sprintf('Cannot find media with id `%s`.', $id));
         }
@@ -204,6 +203,13 @@ class MediaController extends AbstractRestController
 
             if (null !== $draft = $this->getClassContentManager()->getDraft($content)) {
                 $content->setDraft($draft);
+            }
+
+            // we also need to load content's elements draft
+            foreach ($content->getData() as $element) {
+                if (null !== $draft = $this->getClassContentManager()->getDraft($element)) {
+                    $element->setDraft($draft);
+                }
             }
 
             $mediaJson = $media->jsonSerialize();


### PR DESCRIPTION
Updated ``BackBee\ClassContent\ClassContentManager::prepareDraftForCommit`` to always commit all content's elements the first time (when content state is equals to ``1000`` - ``ClassContent::STATE_NEW``).

Also updated ``BackBee\Rest\Controller\MediaController::mediaToJson`` to also hydrate media main content elements draft otherwise we don't get the right image.

This issue aims to resolve [backbee/bb-core-js #570](https://github.com/backbee/BbCoreJs/issues/570).