### PR TITLE
[Rest] updated ClassContentController::postAction to also create drafts for content's elements

### DIFF
--- a/Rest/Controller/ClassContentController.php
+++ b/Rest/Controller/ClassContentController.php
@@ -196,6 +196,12 @@ class ClassContentController extends AbstractRestController
 
         $this->getEntityManager()->persist($content);
         $content->setDraft($this->getClassContentManager()->getDraft($content, true));
+        foreach ($content->getData() as $element) {
+            if ($element instanceof AbstractClassContent) {
+                $element->setDraft($this->getClassContentManager()->getDraft($element, true));
+            }
+        }
+
         $this->getEntityManager()->flush();
 
         return $this->createJsonResponse(null, 201, [


### PR DESCRIPTION
This PR aims to resolve issue #370 reported by @fkroockmann. It is triggered by ``ClassContentController::postAction`` which did not create draft for content's elements so the element's state never passed to ``AbstractClassContent::STATE_NORMAL``.