### PR TITLE
[Tests] created BackBeeTestCase which is more consistent and lightweight #394

### DIFF
--- a/ClassContent/Repository/ClassContentRepository.php
+++ b/ClassContent/Repository/ClassContentRepository.php
@@ -26,6 +26,7 @@ namespace BackBee\ClassContent\Repository;
 use BackBee\BBApplication;
 use BackBee\ClassContent\AbstractClassContent;
 use BackBee\ClassContent\ContentSet;
+use BackBee\ClassContent\Revision;
 use BackBee\NestedNode\Page;
 use BackBee\Security\Token\BBUserToken;
 use BackBee\Util\Doctrine\SettablePaginator;
@@ -722,7 +723,7 @@ class ClassContentRepository extends EntityRepository
     public function removeFromPost(AbstractClassContent $content, $value = null, AbstractClassContent $parent = null)
     {
         if (null !== $draft = $content->getDraft()) {
-            $draft->setState(\BackBee\ClassContent\Revision::STATE_TO_DELETE);
+            $draft->setState(Revision::STATE_TO_DELETE);
         }
 
         return $content;

--- a/ClassContent/Tests/ClassContentPersistenceTest.php
+++ b/ClassContent/Tests/ClassContentPersistenceTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\ClassContent\Test;
+
+use BackBee\ClassContent\AbstractClassContent;
+use BackBee\ClassContent\Element\Text;
+use BackBee\ClassContent\Tests\Mock\MockContent;
+use BackBee\Tests\BackBeeTestCase;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ */
+class ClassContentPersistenceTest extends BackBeeTestCase
+{
+    /**
+     * @var BackBee\ClassContent\ClassContentManager
+     */
+    private static $contentManager;
+
+    public static function setUpBeforeClass()
+    {
+        self::$kernel->resetDatabase();
+
+        $user = self::$kernel->createAuthenticatedUser('content_persistence_test');
+
+        self::$em->persist($user);
+        self::$em->flush($user);
+
+        self::$contentManager = self::$app->getContainer()->get('classcontent.manager');
+        self::$contentManager->setBBUserToken(self::$app->getSecurityContext()->getToken());
+
+    }
+
+    public function setUp()
+    {
+        self::$em->clear();
+
+        self::$kernel->resetDatabase([
+            self::$em->getClassMetadata('BackBee\ClassContent\AbstractClassContent'),
+            self::$em->getClassMetadata('BackBee\ClassContent\Revision'),
+        ]);
+    }
+
+    public function testContentDraftOnFlush()
+    {
+        $content = new MockContent();
+
+        $this->assertNull($content->getDraft());
+        $this->assertNull(self::$contentManager->getDraft($content));
+
+        self::$em->persist($content);
+        self::$em->flush($content);
+
+        $this->assertNotNull($content->getDraft());
+        $this->assertNotNull(self::$contentManager->getDraft($content));
+
+        // Should create draft for content's elements that is instanceof BackBee\ClassContent\AbstractClassContent
+        foreach ($content->getData() as $element) {
+            if ($element instanceof AbstractClassContent) {
+                $this->assertNotNull(self::$contentManager->getDraft($element));
+            }
+        }
+    }
+
+    public function testContentDraftOnFlushWithoutBBUserToken()
+    {
+        $token = self::$app->getSecurityContext()->getToken();
+        self::$app->getSecurityContext()->setToken(null);
+        self::$contentManager->setBBUserToken(null);
+
+        $text = new Text();
+
+        $this->assertNull($text->getDraft());
+
+        self::$em->persist($text);
+        self::$em->flush($text);
+
+        $this->assertNull($text->getDraft());
+
+        self::$app->getSecurityContext()->setToken($token);
+        self::$contentManager->setBBUserToken($token);
+    }
+
+    public function testDeleteContent()
+    {
+        $content = new MockContent();
+
+        self::$em->persist($content);
+        self::$em->flush($content);
+
+        self::$em->clear();
+
+        $uid = $content->getUid();
+        $repository = self::$em->getRepository(get_class($content));
+
+        $this->assertNotNull($content = $repository->find($uid));
+
+        $repository->deleteContent($content);
+        self::$em->flush();
+
+        $this->assertNull($repository->find($uid));
+    }
+
+    public function testAutomaticReplacementOnDeleteClassContentElement()
+    {
+        $content = new MockContent();
+
+        self::$em->persist($content);
+        self::$em->flush($content);
+
+        self::$em->clear();
+
+        $repository = self::$em->getRepository(get_class($content));
+        $content = $repository->find($content->getUid());
+        $titleUid = $content->title->getUid();
+
+        $repository->deleteContent($content->title, true);
+        self::$em->flush();
+
+        $this->assertNotNull($content->title);
+        $this->assertTrue($titleUid !== $content->title->getUid());
+        $this->assertNotNull(
+            self::$em->find(get_class($content->title), $content->title->getUid()),
+            'Replacement title must be persisted into database.'
+        );
+        $this->assertNotNull(
+            self::$contentManager->getDraft($content->title),
+            'Replacement title must also own a draft'
+        );
+    }
+}

--- a/Config/Tests/PersistorTest.php
+++ b/Config/Tests/PersistorTest.php
@@ -31,6 +31,7 @@ use BackBee\Config\Tests\Persistor\FakeContainerBuilder;
 use BackBee\DependencyInjection\Container;
 use BackBee\Site\Site;
 use BackBee\Tests\Mock\ManualBBApplication;
+use BackBee\Tests\TestKernel;
 
 /**
  * Set of tests for BackBee\Config\Persistor.
@@ -263,5 +264,10 @@ class PersistorTest extends \PHPUnit_Framework_TestCase
             $this->configurator->getConfigDefaultSections($this->application->getConfig()),
             $updated_override_section
         ), $this->application->getContainer()->getParameter('config_to_persist'));
+    }
+
+    public static function tearDownAfterClass()
+    {
+        TestKernel::getInstance()->getApplication()->resetStructure();
     }
 }

--- a/Controller/Tests/ControllerResolverTest.php
+++ b/Controller/Tests/ControllerResolverTest.php
@@ -25,7 +25,7 @@ namespace BackBee\Controller\Tests;
 
 use Symfony\Component\HttpFoundation\Request;
 use BackBee\Controller\ControllerResolver;
-use BackBee\Tests\TestCase;
+use BackBee\Tests\BackBeeTestCase;
 
 /**
  * ControllerResolver Test.
@@ -37,11 +37,11 @@ use BackBee\Tests\TestCase;
  *
  * @coversDefaultClass \BackBee\Controller\ControllerResolver
  */
-class ControllerResolverTest extends TestCase
+class ControllerResolverTest extends BackBeeTestCase
 {
     public function test__construct()
     {
-        $resolver = new ControllerResolver($this->getBBApp());
+        $resolver = new ControllerResolver(self::$app);
 
         $this->assertInstanceOf('BackBee\Controller\ControllerResolver', $resolver);
     }
@@ -52,7 +52,7 @@ class ControllerResolverTest extends TestCase
      */
     public function test_getController()
     {
-        $resolver = new ControllerResolver($this->getBBApp());
+        $resolver = new ControllerResolver(self::$app);
 
         $request = new Request();
         $this->assertFalse($resolver->getController($request));

--- a/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -23,13 +23,16 @@
 
 namespace BackBee\DependencyInjection\Tests;
 
-use org\bovigo\vfs\vfsStream;
-use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use BackBee\DependencyInjection\Container;
 use BackBee\DependencyInjection\ContainerBuilder;
 use BackBee\DependencyInjection\ContainerProxy;
 use BackBee\DependencyInjection\Dumper\PhpArrayDumper;
 use BackBee\Tests\Mock\ManualBBApplication;
+use BackBee\Tests\TestKernel;
+
+use org\bovigo\vfs\vfsStream;
+
+use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 
 /**
  * Set of tests for BackBee\DependencyInjection\ContainerBuilder.
@@ -308,5 +311,10 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
                 'BackBee\DependencyInjection\Exception\MissingBootstrapParametersException', $e
             );
         }
+    }
+
+    public static function tearDownAfterClass()
+    {
+        TestKernel::getInstance()->getApplication()->resetStructure();
     }
 }

--- a/DependencyInjection/Tests/ContainerProxyTest.php
+++ b/DependencyInjection/Tests/ContainerProxyTest.php
@@ -23,13 +23,16 @@
 
 namespace BackBee\DependencyInjection\Tests;
 
-use org\bovigo\vfs\vfsStream;
-use Symfony\Component\Yaml\Yaml;
 use BackBee\DependencyInjection\Container;
 use BackBee\DependencyInjection\ContainerInterface;
 use BackBee\DependencyInjection\ContainerProxy;
 use BackBee\DependencyInjection\Dumper\PhpArrayDumper;
 use BackBee\DependencyInjection\Util\ServiceLoader;
+use BackBee\Tests\TestKernel;
+
+use org\bovigo\vfs\vfsStream;
+
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Test for ContainerProxy.
@@ -155,10 +158,6 @@ class ContainerProxyTest extends \PHPUnit_Framework_TestCase
     public function testGetParameter()
     {
         $dumper = new PhpArrayDumper($this->container);
-
-        // vfsStream::setup('directory', 0777, array(
-        //     'dump' => $dumper->dump(array('do_compile' => false))
-        // ));
 
         $container = new ContainerProxy();
         $container->init(unserialize($dumper->dump(array('do_compile' => false))));
@@ -383,5 +382,10 @@ class ContainerProxyTest extends \PHPUnit_Framework_TestCase
         $container->init(unserialize($dumper->dump(array('do_compile' => true))));
 
         $this->assertTrue($container->isCompiled());
+    }
+
+    public static function tearDownAfterClass()
+    {
+        TestKernel::getInstance()->getApplication()->resetStructure();
     }
 }

--- a/DependencyInjection/Tests/Listener/ContainerListenerTest.php
+++ b/DependencyInjection/Tests/Listener/ContainerListenerTest.php
@@ -23,11 +23,13 @@
 
 namespace BackBee\DependencyInjection\Tests\Listener;
 
-use org\bovigo\vfs\vfsStream;
 use BackBee\DependencyInjection\ContainerBuilder;
 use BackBee\DependencyInjection\Listener\ContainerListener;
 use BackBee\Event\Event;
 use BackBee\Tests\Mock\ManualBBApplication;
+use BackBee\Tests\TestKernel;
+
+use org\bovigo\vfs\vfsStream;
 
 /**
  * Set of tests for BackBee\DependencyInjection\Listener\ContainerListener.
@@ -210,5 +212,10 @@ class ContainerListenerTest extends \PHPUnit_Framework_TestCase
         $application->setBase_Dir($base_directory);
 
         return $application;
+    }
+
+    public static function tearDownAfterClass()
+    {
+        TestKernel::getInstance()->getApplication()->resetStructure();
     }
 }

--- a/NestedNode/Tests/AbstractNestedNodeTest.php
+++ b/NestedNode/Tests/AbstractNestedNodeTest.php
@@ -32,7 +32,7 @@ use BackBee\Tests\TestCase;
  * @copyright   Lp digital system
  * @author      c.rouillon <charles.rouillon@lp-digital.fr>
  */
-class AbstractNestedNodeTest extends TestCase
+class AbstractNestedNodeTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \Datetime

--- a/NestedNode/Tests/KeyWordTest.php
+++ b/NestedNode/Tests/KeyWordTest.php
@@ -32,7 +32,7 @@ use BackBee\Tests\TestCase;
  * @copyright   Lp digital system
  * @author      c.rouillon <charles.rouillon@lp-digital.fr>
  */
-class KeyWordTest extends TestCase
+class KeyWordTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \Datetime

--- a/NestedNode/Tests/MediaFolderTest.php
+++ b/NestedNode/Tests/MediaFolderTest.php
@@ -32,7 +32,7 @@ use BackBee\Tests\TestCase;
  * @copyright   Lp digital system
  * @author      c.rouillon <charles.rouillon@lp-digital.fr>
  */
-class MediaFolderTest extends TestCase
+class MediaFolderTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \Datetime

--- a/NestedNode/Tests/MediaTest.php
+++ b/NestedNode/Tests/MediaTest.php
@@ -34,7 +34,7 @@ use BackBee\Tests\TestCase;
  * @copyright   Lp digital system
  * @author      c.rouillon <charles.rouillon@lp-digital.fr>
  */
-class MediaTest extends TestCase
+class MediaTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \Datetime

--- a/NestedNode/Tests/PageTest.php
+++ b/NestedNode/Tests/PageTest.php
@@ -28,7 +28,7 @@ use BackBee\MetaData\MetaDataBag;
 use BackBee\NestedNode\Page;
 use BackBee\Site\Layout;
 use BackBee\Site\Site;
-use BackBee\Tests\TestCase;
+use BackBee\Tests\BackBeeTestCase;
 use BackBee\Workflow\State;
 
 /**
@@ -37,7 +37,7 @@ use BackBee\Workflow\State;
  * @copyright   Lp digital system
  * @author      c.rouillon <charles.rouillon@lp-digital.fr>
  */
-class PageTest extends TestCase
+class PageTest extends BackBeeTestCase
 {
     /**
      * @var \Datetime
@@ -346,28 +346,24 @@ class PageTest extends TestCase
 
     public function testHasChildren()
     {
-        $em = $this->getEntityManager();
-        $repository = $em->getRepository('BackBee\NestedNode\Page');
+        $repository = self::$em->getRepository('BackBee\NestedNode\Page');
 
-        $this->initDb($this->getApplication());
+        self::$kernel->resetDatabase();
 
         $site = new Site(null, array('label' => 'Site 1'));
-        $em->persist($site);
-        $em->flush($site);
+        self::$em->persist($site);
+        self::$em->flush($site);
 
-        $layout = new Layout();
-        $layout->setDataObject($this->getDefaultLayoutZones());
-        $layout->setLabel('test has children');
-        $layout->setPath('path');
-        $em->persist($layout);
-        $em->flush($layout);
+        $layout = self::$kernel->createLayout('test_has_children');
+        self::$em->persist($layout);
+        self::$em->flush($layout);
 
         $uid = 'testhaschildrenpage';
         $parent = new Page($uid, array('title' => 'page'));
         $parent->setLayout($layout);
         $parent->setSite($site);
-        $em->persist($parent);
-        $em->flush($parent);
+        self::$em->persist($parent);
+        self::$em->flush($parent);
 
         // Test without children
         $this->assertFalse(false, $parent->hasChildren());
@@ -380,10 +376,10 @@ class PageTest extends TestCase
 
         $repository->insertNodeAsFirstChildOf($child1, $parent);
 
-        $em->persist($child1);
-        $em->flush($child1);
+        self::$em->persist($child1);
+        self::$em->flush($child1);
 
-        $em->clear();
+        self::$em->clear();
 
         $parent = $repository->find($uid);
 
@@ -397,10 +393,10 @@ class PageTest extends TestCase
 
         $repository->insertNodeAsFirstChildOf($child2, $parent);
 
-        $em->persist($child2);
-        $em->flush($child2);
+        self::$em->persist($child2);
+        self::$em->flush($child2);
 
-        $em->clear();
+        self::$em->clear();
 
         $parent = $repository->find($uid);
 
@@ -492,7 +488,7 @@ class PageTest extends TestCase
      */
     public function testSetPublishingOnRootPagesFails()
     {
-        $rootPage = $this->createRootPage();
+        $rootPage = self::$kernel->createRootPage();
         // first publication
         $rootPage->setPublishing(new \DateTime());
         $rootPage->setPublishing(new \DateTime()); // forbidden
@@ -524,7 +520,7 @@ class PageTest extends TestCase
      */
     public function testSetArchivingOnRootPagesFails()
     {
-        $rootPage = $this->createRootPage();
+        $rootPage = self::$kernel->createRootPage();
         $rootPage->setArchiving(new \DateTime());
     }
 
@@ -608,8 +604,7 @@ class PageTest extends TestCase
     public function testGetParentZoneAtSamePositionIfExists()
     {
         $page = new Page('test', array('title' => 'title', 'url' => 'url'));
-        $layout = new Layout();
-        $page->setLayout($layout->setDataObject($this->getDefaultLayoutZones()));
+        $page->setLayout(self::$kernel->createLayout('test'));
 
         $this->assertFalse($this->page->getParentZoneAtSamePositionIfExists($page->getContentSet()->first()));
         $this->assertFalse($this->page->getParentZoneAtSamePositionIfExists($page->getContentSet()->last()));
@@ -632,7 +627,7 @@ class PageTest extends TestCase
         $thirdcolumn->defaultClassContent = 'inherited';
         $thirdcolumn->options = null;
 
-        $data = $this->getDefaultLayoutZones();
+        $data = self::$kernel->getDefaultLayoutZones();
         $data->templateLayouts[] = $thirdcolumn;
 
         $layout = new Layout();
@@ -744,19 +739,19 @@ class PageTest extends TestCase
      */
     public function testRootPageCantBeArchived()
     {
-        $rootPage = $this->createPage(true);
+        $rootPage = self::$kernel->createPage();
         $rootPage->setArchiving(new \Datetime());
     }
 
     public function testRootPageCantBePublished()
     {
-        $rootPage = $this->createPage(true);
+        $rootPage = self::$kernel->createPage();
         $rootPage->setPublishing(new \Datetime());
     }
 
     public function testRootPageCantBePutOffline()
     {
-        $rootPage = $this->createPage(true);
+        $rootPage = self::$kernel->createPage();
         $rootPage->setState(Page::STATE_ONLINE);
     }
 
@@ -766,6 +761,6 @@ class PageTest extends TestCase
     public function setUp()
     {
         $this->current_time = new \Datetime();
-        $this->page = $this->createPage();
+        $this->page = self::$kernel->createPage();
     }
 }

--- a/NestedNode/Tests/Repository/NestedNodeQueryBuilderTest.php
+++ b/NestedNode/Tests/Repository/NestedNodeQueryBuilderTest.php
@@ -25,7 +25,7 @@ namespace BackBee\NestedNode\Tests\Repository;
 
 use BackBee\NestedNode\Repository\NestedNodeRepository;
 use BackBee\NestedNode\Tests\Mock\MockNestedNode;
-use BackBee\Tests\TestCase;
+use BackBee\Tests\BackBeeTestCase;
 
 /**
  * @category    BackBee
@@ -33,13 +33,8 @@ use BackBee\Tests\TestCase;
  * @copyright   Lp digital system
  * @author      c.rouillon <charles.rouillon@lp-digital.fr>
  */
-class NestedNodeQueryBuilderTest extends TestCase
+class NestedNodeQueryBuilderTest extends BackBeeTestCase
 {
-    /**
-     * @var \BackBee\TestUnit\Mock\MockBBApplication
-     */
-    private $application;
-
     /**
      * @var \BackBee\NestedNode\Tests\Mock\MockNestedNode
      */
@@ -48,7 +43,34 @@ class NestedNodeQueryBuilderTest extends TestCase
     /**
      * @var \BackBee\NestedNode\Repository\NestedNodeRepository
      */
-    private $repo;
+    private $repository;
+
+    public function __construct($name = null, array $data = array(), $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->repository = self::$em->getRepository('BackBee\NestedNode\Tests\Mock\MockNestedNode');
+    }
+
+    /**
+     * Sets up the fixture.
+     */
+    public function setUp()
+    {
+        self::$em->clear();
+
+        self::$kernel->resetDatabase([
+            self::$em->getClassMetaData('BackBee\NestedNode\Tests\Mock\MockNestedNode'),
+        ]);
+
+        $this->root = new MockNestedNode('root');
+        self::$em->persist($this->root);
+        self::$em->flush($this->root);
+
+        $child1 = $this->repository->insertNodeAsLastChildOf(new MockNestedNode('child1'), $this->root);
+        self::$em->persist($child1);
+        self::$em->flush($child1);
+    }
 
     /**
      * @covers \BackBee\NestedNode\Repository\NestedNodeQueryBuilder::andIsNot
@@ -56,7 +78,7 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndIsNot()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andIsNot($this->root);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
@@ -69,7 +91,7 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndRootIs()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andRootIs($this->root);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
@@ -82,14 +104,14 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndParentIs()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andParentIs($this->root);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._parent = :parent0', $q->getDql());
         $this->assertEquals($this->root, $q->getParameter('parent0')->getValue());
 
-        $qn = $this->repo->createQueryBuilder('n')
+        $qn = $this->repository->createQueryBuilder('n')
                 ->andParentIs(null);
 
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._parent IS NULL', $qn->getDql());
@@ -100,7 +122,7 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndLevelEquals()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andLevelEquals(5);
 
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._level = :level0', $q->getDql());
@@ -112,14 +134,14 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndLevelIsLowerThan()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andLevelIsLowerThan(5);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._level <= :level0', $q->getDql());
         $this->assertEquals(5, $q->getParameter('level0')->getValue());
 
-        $qs = $this->repo->createQueryBuilder('n')
+        $qs = $this->repository->createQueryBuilder('n')
                 ->andLevelIsLowerThan(5, true);
 
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._level <= :level0', $qs->getDql());
@@ -131,14 +153,14 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndLevelIsUpperThan()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andLevelIsUpperThan(5);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._level >= :level0', $q->getDql());
         $this->assertEquals(5, $q->getParameter('level0')->getValue());
 
-        $qs = $this->repo->createQueryBuilder('n')
+        $qs = $this->repository->createQueryBuilder('n')
                 ->andLevelIsUpperThan(5, true);
 
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._level >= :level0', $qs->getDql());
@@ -150,7 +172,7 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndLeftnodeEquals()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andLeftnodeEquals(5);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
@@ -163,14 +185,14 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndLeftnodeIsLowerThan()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andLeftnodeIsLowerThan(5);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._leftnode <= :leftnode0', $q->getDql());
         $this->assertEquals(5, $q->getParameter('leftnode0')->getValue());
 
-        $qs = $this->repo->createQueryBuilder('n')
+        $qs = $this->repository->createQueryBuilder('n')
                 ->andLeftnodeIsLowerThan(5, true);
 
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._leftnode <= :leftnode0', $qs->getDql());
@@ -182,14 +204,14 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndLeftnodeIsUpperThan()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andLeftnodeIsUpperThan(5);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._leftnode >= :leftnode0', $q->getDql());
         $this->assertEquals(5, $q->getParameter('leftnode0')->getValue());
 
-        $qs = $this->repo->createQueryBuilder('n')
+        $qs = $this->repository->createQueryBuilder('n')
                 ->andLeftnodeIsUpperThan(5, true);
 
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._leftnode >= :leftnode0', $qs->getDql());
@@ -201,7 +223,7 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndRightnodeEquals()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andRightnodeEquals(5);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
@@ -214,14 +236,14 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndRightnodeIsLowerThan()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andRightnodeIsLowerThan(5);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._rightnode <= :rightnode0', $q->getDql());
         $this->assertEquals(5, $q->getParameter('rightnode0')->getValue());
 
-        $qs = $this->repo->createQueryBuilder('n')
+        $qs = $this->repository->createQueryBuilder('n')
                 ->andRightnodeIsLowerThan(5, true);
 
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._rightnode <= :rightnode0', $qs->getDql());
@@ -233,7 +255,7 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndRightnodeIsUpperThan()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andRightnodeIsUpperThan(5);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
@@ -253,7 +275,7 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndIsSiblingsOf()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andIsSiblingsOf($this->root);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
@@ -274,7 +296,7 @@ class NestedNodeQueryBuilderTest extends TestCase
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._uid = :uid0 AND n._parent IS NULL ORDER BY n._rightnode desc', $q->getDql());
         $this->assertEquals($this->root->getUid(), $q->getParameter('uid0')->getValue());
 
-        $child1 = $this->repo->find('child1');
+        $child1 = $this->repository->find('child1');
         $q->resetDQLPart('where')
                 ->setParameters(array())
                 ->andIsSiblingsOf($child1);
@@ -316,8 +338,8 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndIsPreviousSiblingOf()
     {
-        $child1 = $this->repo->find('child1');
-        $q = $this->repo->createQueryBuilder('n')
+        $child1 = $this->repository->find('child1');
+        $q = $this->repository->createQueryBuilder('n')
                 ->andIsPreviousSiblingOf($child1);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
@@ -331,8 +353,8 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndIsPreviousSiblingsOf()
     {
-        $child1 = $this->repo->find('child1');
-        $q = $this->repo->createQueryBuilder('n')
+        $child1 = $this->repository->find('child1');
+        $q = $this->repository->createQueryBuilder('n')
                 ->andIsPreviousSiblingsOf($child1);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
@@ -346,8 +368,8 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndIsNextSiblingOf()
     {
-        $child1 = $this->repo->find('child1');
-        $q = $this->repo->createQueryBuilder('n')
+        $child1 = $this->repository->find('child1');
+        $q = $this->repository->createQueryBuilder('n')
                 ->andIsNextSiblingOf($child1);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
@@ -361,8 +383,8 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndIsNextSiblingsOf()
     {
-        $child1 = $this->repo->find('child1');
-        $q = $this->repo->createQueryBuilder('n')
+        $child1 = $this->repository->find('child1');
+        $q = $this->repository->createQueryBuilder('n')
                 ->andIsNextSiblingsOf($child1);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
@@ -377,8 +399,8 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndIsAncestorOf()
     {
-        $child1 = $this->repo->find('child1');
-        $q = $this->repo->createQueryBuilder('n')
+        $child1 = $this->repository->find('child1');
+        $q = $this->repository->createQueryBuilder('n')
                 ->andIsAncestorOf($child1);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
@@ -412,8 +434,8 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testAndIsDescendantOf()
     {
-        $child1 = $this->repo->find('child1');
-        $q = $this->repo->createQueryBuilder('n')
+        $child1 = $this->repository->find('child1');
+        $q = $this->repository->createQueryBuilder('n')
                 ->andIsDescendantOf($child1);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
@@ -447,7 +469,7 @@ class NestedNodeQueryBuilderTest extends TestCase
      */
     public function testOrderByMultiple()
     {
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->orderByMultiple();
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n ORDER BY n._leftnode asc', $q->getDql());
 
@@ -465,7 +487,7 @@ class NestedNodeQueryBuilderTest extends TestCase
     {
         $now = new \DateTime();
 
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andModifiedIsLowerThan($now);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
@@ -479,59 +501,10 @@ class NestedNodeQueryBuilderTest extends TestCase
     {
         $now = new \DateTime();
 
-        $q = $this->repo->createQueryBuilder('n')
+        $q = $this->repository->createQueryBuilder('n')
                 ->andModifiedIsGreaterThan($now);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\NestedNodeQueryBuilder', $q);
         $this->assertEquals('SELECT n FROM BackBee\NestedNode\Tests\Mock\MockNestedNode n WHERE n._modified > :date0', $q->getDql());
-    }
-
-    /**
-     * Sets up the fixture.
-     */
-    public function setUp()
-    {
-        $this->application = $this->getBBApp();
-        $em = $this->application->getEntityManager();
-
-        $st = new \Doctrine\ORM\Tools\SchemaTool($em);
-        $st->createSchema(array($em->getClassMetaData('BackBee\NestedNode\Tests\Mock\MockNestedNode')));
-
-        $this->_setRepo()
-                ->_setRoot();
-    }
-
-    /**
-     * Sets the NestedNode Repository.
-     *
-     * @return \BackBee\NestedNode\Tests\Repository\NestedNodeRepositoryTest
-     */
-    private function _setRepo()
-    {
-        $this->repo = $this->application
-            ->getEntityManager()
-            ->getRepository('BackBee\NestedNode\Tests\Mock\MockNestedNode')
-        ;
-
-        return $this;
-    }
-
-    /**
-     * Initiate a new tree with node added as last child.
-     *
-     * @return \BackBee\NestedNode\Tests\Repository\NestedNodeRepositoryTest
-     */
-    private function _setRoot()
-    {
-        $this->root = new MockNestedNode('root');
-
-        $em = $this->application->getEntityManager();
-        $em->persist($this->root);
-        $em->flush($this->root);
-
-        $child1 = $this->repo->insertNodeAsLastChildOf(new MockNestedNode('child1'), $this->root);
-        $em->flush($child1);
-
-        return $this;
     }
 }

--- a/NestedNode/Tests/Repository/PageQueryBuilderTest.php
+++ b/NestedNode/Tests/Repository/PageQueryBuilderTest.php
@@ -24,9 +24,10 @@
 namespace BackBee\NestedNode\Tests\Repository;
 
 use BackBee\NestedNode\Page;
-use BackBee\NestedNode\Repository\PageRepository;
+use BackBee\NestedNode\Repository\PageQueryBuilder;
 use BackBee\Site\Layout;
-use BackBee\Tests\TestCase;
+use BackBee\Tests\BackBeeTestCase;
+
 
 /**
  * @category    BackBee
@@ -34,25 +35,39 @@ use BackBee\Tests\TestCase;
  * @copyright   Lp digital system
  * @author      c.rouillon <charles.rouillon@lp-digital.fr>
  */
-class PageQueryBuilderTest extends TestCase
+class PageQueryBuilderTest extends BackBeeTestCase
 {
-    /**
-     * @var \BackBee\TestUnit\Mock\MockBBApplication
-     */
-    private $application;
+    private static $previousDateFormat;
 
     /**
      * @var \BackBee\NestedNode\Repository\PageRepository
      */
-    private $repo;
+    private $repository;
+
+    public function __construct($name = null, array $data = array(), $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->repository = self::$em->getRepository('BackBee\NestedNode\Page');
+    }
+
+    public static function setUpBeforeClass()
+    {
+        self::$kernel->resetDatabase();
+
+        self::$previousDateFormat = PageQueryBuilder::$config['dateSchemeForPublishing'];
+
+        PageQueryBuilder::$config = array(
+            'dateSchemeForPublishing' => 'Y-m-d H:i:00',
+        );
+    }
 
     /**
      * @covers \BackBee\NestedNode\Repository\PageQueryBuilder::andIsOnline
      */
     public function testAndIsOnline()
     {
-        $q = $this->repo->createQueryBuilder('p')
-                ->andIsOnline();
+        $q = $this->repository->createQueryBuilder('p')->andIsOnline();
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
         $this->assertEquals('SELECT p FROM BackBee\NestedNode\Page p WHERE p._state IN (:states0) AND (p._publishing IS NULL OR p._publishing <= :now0) AND (p._archiving IS NULL OR p._archiving > :now0)', $q->getDql());
@@ -65,7 +80,7 @@ class PageQueryBuilderTest extends TestCase
      */
     public function testAndIsVisible()
     {
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andIsVisible();
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
@@ -80,7 +95,7 @@ class PageQueryBuilderTest extends TestCase
     public function testAndLayoutIs()
     {
         $layout = new Layout();
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andLayoutIs($layout);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
@@ -94,7 +109,7 @@ class PageQueryBuilderTest extends TestCase
     public function testAndIsOnlineSiblingsOf()
     {
         $page = new Page();
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andIsOnlineSiblingsOf($page);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
@@ -107,7 +122,7 @@ class PageQueryBuilderTest extends TestCase
     public function testAndIsPreviousOnlineSiblingOf()
     {
         $page = new Page();
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andIsPreviousOnlineSiblingOf($page);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
@@ -120,7 +135,7 @@ class PageQueryBuilderTest extends TestCase
     public function testAndIsNextOnlineSiblingOf()
     {
         $page = new Page();
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andIsNextOnlineSiblingOf($page);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
@@ -133,7 +148,7 @@ class PageQueryBuilderTest extends TestCase
     public function testAndIsVisibleSiblingsOf()
     {
         $page = new Page();
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andIsVisibleSiblingsOf($page);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
@@ -146,7 +161,7 @@ class PageQueryBuilderTest extends TestCase
     public function testAndIsPreviousVisibleSiblingOf()
     {
         $page = new Page();
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andIsPreviousVisibleSiblingOf($page);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
@@ -159,7 +174,7 @@ class PageQueryBuilderTest extends TestCase
     public function testAndIsNextVisibleSiblingOf()
     {
         $page = new Page();
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andIsNextVisibleSiblingOf($page);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
@@ -171,7 +186,7 @@ class PageQueryBuilderTest extends TestCase
      */
     public function testAndStateIsIn()
     {
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andStateIsIn(Page::STATE_ONLINE);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
@@ -191,7 +206,7 @@ class PageQueryBuilderTest extends TestCase
      */
     public function testAndStateIsNotIn()
     {
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andStateIsNotIn(Page::STATE_ONLINE);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
@@ -211,7 +226,7 @@ class PageQueryBuilderTest extends TestCase
      */
     public function testAndStateIsLowerThan()
     {
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andStateIsLowerThan(Page::STATE_DELETED);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
@@ -225,7 +240,7 @@ class PageQueryBuilderTest extends TestCase
     public function testAndSiteIs()
     {
         $site = new \BackBee\Site\Site();
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andSiteIs($site);
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
@@ -238,7 +253,7 @@ class PageQueryBuilderTest extends TestCase
      */
     public function testAndTitleIsLike()
     {
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andTitleIsLike('test');
 
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
@@ -252,7 +267,7 @@ class PageQueryBuilderTest extends TestCase
     {
         $now = new \DateTime();
 
-        $q = $this->repo->createQueryBuilder('p')
+        $q = $this->repository->createQueryBuilder('p')
                 ->andSearchCriteria('fake');
         $this->assertInstanceOf('BackBee\NestedNode\Repository\PageQueryBuilder', $q);
         $this->assertEquals('SELECT p FROM BackBee\NestedNode\Page p', $q->getDql());
@@ -293,27 +308,17 @@ class PageQueryBuilderTest extends TestCase
      */
     public function setUp()
     {
-        $this->application = $this->getBBApp();
-        $em = $this->application->getEntityManager();
+        self::$em->clear();
 
-        $st = new \Doctrine\ORM\Tools\SchemaTool($em);
-        $st->createSchema(array($em->getClassMetaData('BackBee\NestedNode\Page')));
-
-        $this->_setRepo();
+        self::$kernel->resetDatabase([
+            self::$em->getClassMetaData('BackBee\NestedNode\Page'),
+        ]);
     }
 
-    /**
-     * Sets the NestedNode Repository.
-     *
-     * @return \BackBee\NestedNode\Tests\Repository\NestedNodeRepositoryTest
-     */
-    private function _setRepo()
+    public static function tearDownAfterClass()
     {
-        $this->repo = $this->application
-            ->getEntityManager()
-            ->getRepository('BackBee\NestedNode\Page')
-        ;
-
-        return $this;
+        PageQueryBuilder::$config = array(
+            'dateSchemeForPublishing' => self::$previousDateFormat,
+        );
     }
 }

--- a/Rest/Patcher/RightManager.php
+++ b/Rest/Patcher/RightManager.php
@@ -100,7 +100,12 @@ class RightManager
      */
     public function addAuthorizationMapping($entity, $mapping)
     {
-        $this->rights[get_class($entity)] = $mapping;
+        $classname = get_class($entity);
+        if (!isset($this->rights[$classname])) {
+            $this->buildRights($classname);
+        }
+
+        $this->rights[$classname] = array_merge($this->rights[$classname], $mapping);
 
         return $this;
     }

--- a/Rest/Tests/Controller/ClassContentControllerTest.php
+++ b/Rest/Tests/Controller/ClassContentControllerTest.php
@@ -26,7 +26,7 @@ namespace BackBee\Rest\Tests\Controller;
 use Symfony\Component\Yaml\Yaml;
 use BackBee\ClassContent\Category;
 use BackBee\Rest\Controller\ClassContentController;
-use BackBee\Tests\TestCase;
+use BackBee\Tests\BackBeeTestCase;
 
 /**
  * Test for AclController class.
@@ -39,26 +39,12 @@ use BackBee\Tests\TestCase;
  * @coversDefaultClass \BackBee\Rest\Controller\ClassContentController
  * @group Rest
  */
-class ClassContentControllerTest extends TestCase
+class ClassContentControllerTest extends BackBeeTestCase
 {
     public function testGetCategory()
     {
-        $app = $this->getApplication();
-        file_put_contents(
-            $app->getRepository().DIRECTORY_SEPARATOR.'ClassContent'.DIRECTORY_SEPARATOR.'test.yml',
-            Yaml::dump([
-                'test' => [
-                    'properties' => [
-                        'name'        => 'Test content',
-                        'description' => 'ClassContentController test content description',
-                        'category'    => ['Test'],
-                    ],
-                ],
-            ])
-        );
-
-        $categoryManager = $app->getContainer()->get('classcontent.category_manager');
-        $controller = new ClassContentController($app);
+        $categoryManager = self::$app->getContainer()->get('classcontent.category_manager');
+        $controller = new ClassContentController(self::$app);
 
         // Test ClassContentController::getCategoryCollectionAction
         $expectedResponse = [];
@@ -67,13 +53,15 @@ class ClassContentControllerTest extends TestCase
         }
 
         $allCategoriesResponse = $controller->getCategoryCollectionAction();
+
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $allCategoriesResponse);
         $this->assertEquals(json_encode($expectedResponse), $allCategoriesResponse->getContent());
 
         // Test ClassContentController::getCategoryCollectionAction
-        $expectedResponse = $categoryManager->getCategory('test');
+        $expectedResponse = $categoryManager->getCategory('Demo');
 
-        $categoryResponse = $controller->getCategoryAction('test');
+        $categoryResponse = $controller->getCategoryAction('Demo');
+
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $categoryResponse);
         $this->assertEquals(json_encode($expectedResponse), $categoryResponse->getContent());
     }
@@ -84,7 +72,7 @@ class ClassContentControllerTest extends TestCase
      */
     public function testGetInvalidCategory()
     {
-        $controller = new ClassContentController($this->getApplication());
+        $controller = new ClassContentController(self::$app);
         $controller->getCategoryAction('invalid');
     }
 }

--- a/Tests/BackBeeTestCase.php
+++ b/Tests/BackBeeTestCase.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Tests;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ */
+class BackBeeTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \BackBee\Tests\TestKernel
+     */
+    public static $kernel;
+
+    /**
+     * @var \BackBee\Tests\BackBeeTestCase
+     */
+    public static $app;
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    public static $em;
+}

--- a/Tests/Mock/MockBBApplication.php
+++ b/Tests/Mock/MockBBApplication.php
@@ -58,7 +58,7 @@ class MockBBApplication extends BBApplication
      *
      * @var \org\bovigo\vfs\vfsStreamDirectory
      */
-    private $_mock_basedir;
+    private $mockedStructure;
 
     /**
      * Mock the BBApplication class constructor.
@@ -117,6 +117,14 @@ class MockBBApplication extends BBApplication
         return vfsStream::url('repositorydir/cache');
     }
 
+    public function resetStructure()
+    {
+        if (null !== $this->mockedStructure) {
+            vfsStream::umask(0000);
+            vfsStream::setup('repositorydir', 0777, $this->mockedStructure);
+        }
+    }
+
     /**
      * Initilizes the mock structure.
      *
@@ -125,20 +133,24 @@ class MockBBApplication extends BBApplication
     protected function mockInitStructure(array $mockConfig = null)
     {
         if (null === $mockConfig) {
-            $mockConfig = [
+            $this->mockedStructure = [
                 'ClassContent' => [],
                 'Config' => [
                     'bootstrap.yml' => file_get_contents(__DIR__.'/../Config/bootstrap.yml'),
-                    'bundles.yml' => file_get_contents(__DIR__.'/../Config/bundles.yml'),
-                    'config.yml' => file_get_contents(__DIR__.'/../Config/config.yml'),
-                    'doctrine.yml' => file_get_contents(__DIR__.'/../Config/doctrine.yml'),
-                    'logging.yml' => file_get_contents(__DIR__.'/../Config/logging.yml'),
-                    'security.yml' => file_get_contents(__DIR__.'/../Config/security.yml'),
-                    'services.yml' => file_get_contents(__DIR__.'/../Config/services.yml'),
+                    'bundles.yml'   => file_get_contents(__DIR__.'/../Config/bundles.yml'),
+                    'config.yml'    => file_get_contents(__DIR__.'/../Config/config.yml'),
+                    'doctrine.yml'  => file_get_contents(__DIR__.'/../Config/doctrine.yml'),
+                    'logging.yml'   => file_get_contents(__DIR__.'/../Config/logging.yml'),
+                    'security.yml'  => file_get_contents(__DIR__.'/../Config/security.yml'),
+                    'services.yml'  => file_get_contents(__DIR__.'/../Config/services.yml'),
                 ],
-                'Layouts' => ['default.twig' => '<html></html>'],
+                'Layouts' => [
+                    'default.twig' => '<html></html>',
+                ],
                 'Data' => [
-                    'Media' => ['BackBee.png' => file_get_contents(__DIR__.'/../Fixtures/Resources/BackBee.png')],
+                    'Media' => [
+                        'BackBee.png' => file_get_contents(__DIR__.'/../Fixtures/Resources/BackBee.png'),
+                    ],
                     'Storage' => [],
                     'Tmp' => [],
                 ],
@@ -149,8 +161,7 @@ class MockBBApplication extends BBApplication
             ];
         }
 
-        vfsStream::umask(0000);
-        $this->_mock_basedir = vfsStream::setup('repositorydir', 0777, $mockConfig);
+        $this->resetStructure();
 
         return $this;
     }

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -59,13 +59,6 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $this->root_folder = self::getRootFolder();
         $this->BackBee_folder = $this->root_folder.DIRECTORY_SEPARATOR.'BackBee';
         $this->repository_folder = $this->root_folder.DIRECTORY_SEPARATOR.'repository';
-
-        $BackBee_autoloader = new AutoLoader();
-
-        $BackBee_autoloader->setApplication($this->getBBApp())
-            ->register()
-            ->registerNamespace('BackBee\ClassContent\Element', __DIR__.'/../ClassContent/Element')
-        ;
     }
 
     public function getClassContentDir()

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace BackBee\Tests;
+
+use BackBee\Installer\EntityFinder;
+use BackBee\NestedNode\Page;
+use BackBee\Security\Token\BBUserToken;
+use BackBee\Security\Group;
+use BackBee\Security\User;
+use BackBee\Site\Layout;
+use BackBee\Tests\Mock\MockBBApplication;
+
+use Doctrine\ORM\Tools\SchemaTool;
+
+use Symfony\Component\Security\Acl\Dbal\Schema;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ */
+final class TestKernel
+{
+    /**
+     * Singleton pattern, unique instance of TestKernel.
+     *
+     * @var TestKernel
+     */
+    private static $instance;
+
+    /**
+     * @var MockBBApplication
+     */
+    private $app;
+
+    /**
+     * Returns the unique instance of TestKernel.
+     *
+     * @return TestKernel
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new TestKernel();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Returns TestKernel unique MockBBApplication instance.
+     *
+     * @return MockBBApplication
+     */
+    public function getApplication()
+    {
+        return $this->app;
+    }
+
+    /**
+     * Returns TestKernel unique application's EntityManager instance.
+     *
+     * @return \Doctrine\ORM\EntityManager
+     */
+    public function getEntityManager()
+    {
+        return $this->app->getEntityManager();
+    }
+
+    /**
+     * Reset partially or completely the database.
+     *
+     * @param  array|null $entityMetadata The array that contains only metadata of entities we want to create
+     * @param  boolean    $hardReset      This option force hard reset of the entire database
+     * @return self
+     */
+    public function resetDatabase(array $entityMetadata = null, $hardReset = false)
+    {
+        $schemaTool = new SchemaTool($this->getEntityManager());
+
+        if (null === $entityMetadata || true === $hardReset) {
+            $schemaTool->dropDatabase();
+        } else {
+            $schemaTool->dropSchema($entityMetadata);
+        }
+
+        if (null === $entityMetadata) {
+            $entityFinder = new EntityFinder($this->getApplication()->getBBDir());
+
+            $metadataDriver = $this->getEntityManager()->getConfiguration()->getMetadataDriverImpl();
+            foreach ($this->getEntityPaths() as $path) {
+                $metadataDriver->addPaths([$path]);
+                $metadataDriver->addExcludePaths($entityFinder->getExcludePaths($path));
+            }
+
+            $entityMetadata = $metadata = $this->getEntityManager()->getMetadataFactory()->getAllMetadata();
+            $this->getEntityManager()
+                ->getClassMetadata('BackBee\ClassContent\AbstractClassContent')
+                ->addDiscriminatorMapClass(
+                    'BackBee\ClassContent\Tests\Mock\MockContent',
+                    'BackBee\ClassContent\Tests\Mock\MockContent'
+                )
+            ;
+        }
+
+        $schemaTool->createSchema($entityMetadata);
+
+        return $this;
+    }
+
+    public function resetAclSchema()
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        $tablesMapping = [
+            'class_table_name'         => 'acl_classes',
+            'entry_table_name'         => 'acl_entries',
+            'oid_table_name'           => 'acl_object_identities',
+            'oid_ancestors_table_name' => 'acl_object_identity_ancestors',
+            'sid_table_name'           => 'acl_security_identities',
+        ];
+
+        foreach ($tablesMapping as $tableName) {
+            $conn->executeQuery(sprintf('DROP TABLE IF EXISTS %s', $tableName));
+        }
+
+        $schema = new Schema($tablesMapping);
+
+        $platform = $conn->getDatabasePlatform();
+
+        foreach ($schema->toSql($platform) as $query) {
+            $conn->executeQuery($query);
+        }
+
+        return $this;
+    }
+
+    public function createRootPage($uid = null)
+    {
+        $page = new Page($uid, [
+            'title' => 'title',
+            'url'   => 'url',
+        ]);
+
+        $page->setLayout($this->createLayout('test'));
+
+        return $page;
+    }
+
+    public function createPage($uid = null)
+    {
+        $page = $this->createRootPage($uid);
+        $page->setParent($this->createRootPage());
+
+        return $page;
+    }
+
+    public function createLayout($label)
+    {
+        $layout = new Layout();
+        $layout->setLabel($label);
+        $layout->setPath('/'.$label);
+        $layout->setDataObject($this->getDefaultLayoutZones());
+
+        return $layout;
+    }
+
+    /**
+     * Builds a default set of layout zones.
+     *
+     * @return \stdClass
+     */
+    public function getDefaultLayoutZones()
+    {
+        $mainzone = new \stdClass();
+        $mainzone->id = 'main';
+        $mainzone->defaultContainer = null;
+        $mainzone->target = '#target';
+        $mainzone->gridClassPrefix = 'row';
+        $mainzone->gridSize = 8;
+        $mainzone->mainZone = true;
+        $mainzone->defaultClassContent = 'ContentSet';
+        $mainzone->options = null;
+
+        $asidezone = new \stdClass();
+        $asidezone->id = 'aside';
+        $asidezone->defaultContainer = null;
+        $asidezone->target = '#target';
+        $asidezone->gridClassPrefix = 'row';
+        $asidezone->gridSize = 4;
+        $asidezone->mainZone = false;
+        $asidezone->defaultClassContent = 'inherited';
+        $asidezone->options = null;
+
+        $data = new \stdClass();
+        $data->templateLayouts = [
+            $mainzone,
+            $asidezone,
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Creates a user for the specified group and authenticates a BBUserToken with the newly created user.
+     *
+     * Note that the token is setted into application security context.
+     *
+     * @param string $groupId
+     * @return User
+     */
+    public function createAuthenticatedUser($groupId, array $roles = ['ROLE_API_USER'])
+    {
+        $em    = $this->getEntityManager();
+        $group = $em->getRepository('BackBee\Security\Group')->findOneBy([
+            '_name' => $groupId,
+        ]);
+
+        if (null === $group) {
+            $group = new Group();
+            $group->setName($groupId);
+            $em->persist($group);
+            $em->flush($group);
+        }
+
+        $user = new User();
+        $user
+            ->setEmail('admin@backbee.com')
+            ->setLogin('admin')
+            ->setPassword('pass')
+            ->setApiKeyPrivate(uniqid('PRIVATE', true))
+            ->setApiKeyPublic(uniqid('PUBLIC', true))
+            ->setApiKeyEnabled(true)
+            ->addGroup($group)
+        ;
+
+        $token = new BBUserToken($roles);
+        $token->setAuthenticated(true);
+        $token
+            ->setUser($user)
+            ->setCreated(new \DateTime())
+            ->setLifetime(300)
+        ;
+
+        $this->app->getSecurityContext()->setToken($token);
+
+        return $user;
+    }
+
+    /**
+     * Creates an instance of TestKernel and initialize application's autoloader.
+     */
+    private function __construct()
+    {
+        $this->app = new MockBBApplication(null, 'test');
+
+        $this->app->getAutoloader()
+            ->register()
+            ->registerNamespace('BackBee\ClassContent\Element', $this->buildPath([
+                $this->getApplication()->getBBDir(),
+                'ClassContent',
+                'Element',
+            ]))
+        ;
+    }
+
+    /**
+     * Returns array that contains every application entity path.
+     *
+     * @return array
+     */
+    private function getEntityPaths()
+    {
+        $bbDir = $this->getApplication()->getBBDir();
+
+        return [
+            $this->buildPath([$bbDir, 'Bundle']),
+            $this->buildPath([$bbDir, 'Cache', 'DAO']),
+            $this->buildPath([$bbDir, 'ClassContent']),
+            $this->buildPath([$bbDir, 'ClassContent', 'Indexes']),
+            $this->buildPath([$bbDir, 'Logging']),
+            $this->buildPath([$bbDir, 'NestedNode']),
+            $this->buildPath([$bbDir, 'Security']),
+            $this->buildPath([$bbDir, 'Site']),
+            $this->buildPath([$bbDir, 'Stream', 'ClassWrapper']),
+            $this->buildPath([$bbDir, 'Util', 'Sequence', 'Entity']),
+            $this->buildPath([$bbDir, 'Workflow']),
+        ];
+    }
+
+    /**
+     * Builds path with provided array by linking every piece with directory seperator.
+     *
+     * @param  array  $pieces The final path pieces
+     * @return string
+     */
+    private function buildPath(array $pieces)
+    {
+        return implode(DIRECTORY_SEPARATOR, $pieces);
+    }
+}

--- a/Tests/bootstrap.php.dist
+++ b/Tests/bootstrap.php.dist
@@ -2,5 +2,8 @@
 
 require(__DIR__.'/../vendor/autoload.php');
 
-$unitTests = new BackBee\Tests\TestCase();
-$unitTests->initAutoload();
+$kernel = BackBee\Tests\TestKernel::getInstance();
+
+BackBee\Tests\BackBeeTestCase::$kernel = $kernel;
+BackBee\Tests\BackBeeTestCase::$app = $kernel->getApplication();
+BackBee\Tests\BackBeeTestCase::$em = $kernel->getApplication()->getEntityManager();


### PR DESCRIPTION
Created ``BackBee\Tests\BackBeeTestCase`` which is more consistent than ``BackBee\Tests\TestCase`` for several reasons:

- provide UNIQUE instance of ``BBMockApplication``
- autoloading BackBee test suite is now simple, just invoke ``BackBeeTestCase::prepare`` in bootstrap.php.dist (multiple calls is also prevented)
- API simplified and more useful
- removed unused methods
- massive improvements of database management

Also added ``BackBee\Tests\ClassContentPersistenceTest`` to test ClassContent and its revisions behavior on deletion and persistence process.

ping @crouillon and @mickaelandrieu, what do you think about it? First step is to have these two ``TestCase`` classes but we will quickly remove the old one and adapt every test class.