### PR TITLE
[Rest] updated ClassContentController::findContentsByCriterias to also hydrate contents draft

### DIFF
--- a/Rest/Controller/ClassContentController.php
+++ b/Rest/Controller/ClassContentController.php
@@ -672,10 +672,16 @@ class ClassContentController extends AbstractRestController
         unset($criterias['order_by']);
         unset($criterias['order_direction']);
 
-        return $this->getEntityManager()
+        $contents = $this->getEntityManager()
             ->getRepository('BackBee\ClassContent\AbstractClassContent')
             ->findContentsBySearch($classnames, $order_infos, $pagination, $criterias)
         ;
+
+        foreach ($contents as $content) {
+            $content->setDraft($this->getClassContentManager()->getDraft($content));
+        }
+
+        return $contents;
     }
 
     /**


### PR DESCRIPTION
Currently content's draft is not hydrated when we get content collection if we are logged, this PR fixes it.