### PR TITLE
[layout] Avoid infinite loop when picpath is egal to null

### DIFF
--- a/Site/Repository/LayoutRepository.php
+++ b/Site/Repository/LayoutRepository.php
@@ -210,9 +210,12 @@ class LayoutRepository extends EntityRepository
     public function removeThumbnail(Layout $layout, BBApplication $app)
     {
         $thumbnailfile = $layout->getPicPath();
+        if (empty($thumbnail)) {
+            return true;
+        }
         File::resolveFilepath($thumbnailfile, null, array('include_path' => $app->getResourceDir()));
 
-        while (true === file_exists($thumbnailfile) && true === is_writable($thumbnailfile)) {
+        while (true === is_file($thumbnailfile) && true === is_writable($thumbnailfile)) {
             @unlink($thumbnailfile);
 
             $thumbnailfile = $layout->getPicPath();


### PR DESCRIPTION
When a layout picpath is null we try to unlink a folder that action create an infinite loop because the while condition stay every time true :

```php
true === file_exists($thumbnailfile) && true === is_writable($thumbnailfile)
```

To avoid this problem I have use `is_file` because it's more restrictive than `file_exists`.