### PR TITLE
[WIP][ClassContent] updated CategoryManager and content rest controller to accept 'only_visible' option

### DIFF
--- a/ClassContent/CategoryManager.php
+++ b/ClassContent/CategoryManager.php
@@ -95,7 +95,7 @@ class CategoryManager
         return $this->categories;
     }
 
-    public function getClassContentClassnamesByCategory($name)
+    public function getClassContentClassnamesByCategory($name, $onlyVisible = false)
     {
         $category = $this->getCategory($name);
         if (null === $category) {
@@ -104,7 +104,9 @@ class CategoryManager
 
         $classnames = [];
         foreach ($category->getBlocks() as $block) {
-            $classnames[] = AbstractClassContent::getClassnameByContentType($block->type);
+            if (false === $onlyVisible || (true === $onlyVisible && true === $block->visible)) {
+                $classnames[] = AbstractClassContent::getClassnameByContentType($block->type);
+            }
         }
 
         return $classnames;

--- a/Rest/Controller/ClassContentController.php
+++ b/Rest/Controller/ClassContentController.php
@@ -104,7 +104,12 @@ class ClassContentController extends AbstractRestController
             $start = 0;
         } else {
             if (null !== $categoryName) {
-                $contents = $this->getClassContentByCategory($categoryName, $start, $count);
+                $contents = $this->getClassContentByCategory(
+                    $categoryName,
+                    $request->request->has('only_visible'),
+                    $start,
+                    $count
+                );
             } else {
                 $classnames = $this->getClassContentManager()->getAllClassContentClassnames();
                 $contents = $this->findContentsByCriterias($classnames, $start, $count);
@@ -565,9 +570,13 @@ class ClassContentController extends AbstractRestController
      *
      * @return null|Paginator
      */
-    private function getClassContentByCategory($name, $start, $count)
+    private function getClassContentByCategory($name, $onlyVisible, $start, $count)
     {
-        return $this->findContentsByCriterias($this->getClassContentClassnamesByCategory($name), $start, $count);
+        return $this->findContentsByCriterias(
+            $this->getClassContentClassnamesByCategory($name, $onlyVisible),
+            $start,
+            $count
+        );
     }
 
     /**
@@ -604,10 +613,10 @@ class ClassContentController extends AbstractRestController
      *
      * @return array
      */
-    private function getClassContentClassnamesByCategory($name)
+    private function getClassContentClassnamesByCategory($name, $onlyVisible)
     {
         try {
-            return $this->getCategoryManager()->getClassContentClassnamesByCategory($name);
+            return $this->getCategoryManager()->getClassContentClassnamesByCategory($name, $onlyVisible);
         } catch (\InvalidArgumentException $e) {
             throw new NotFoundHttpException($e->getMessage());
         }


### PR DESCRIPTION
With this ``only_visible`` option we can easily display into content selector only the contents that are visibles and availables as drag and droppable content.

@hbaptiste this will be useful for you, you will only need to add a query parameter into the url, example: ``GET /rest/1/classcontent?category=Article&only_online``

This PR still in progress, I will add some tests.