### PR TITLE
Dispatch rest event onKernelController and onKernelResponse

### DIFF
--- a/Config/events.yml
+++ b/Config/events.yml
@@ -90,6 +90,7 @@ kernel.exception:
 
 kernel.controller:
     listeners:
+        - [@rest.listener.event_dispatcher, onKernelController]
         - [@rest.listener.param_converter, onKernelController]
         - [@rest.listener.security, onKernelController]
         - [@rest.listener.validation, onKernelController]
@@ -97,6 +98,7 @@ kernel.controller:
 
 kernel.response:
     listeners:
+        - [@rest.listener.event_dispatcher, onKernelResponse]
         - [@profiler.toolbar.listener, onKernelResponse]
         - [@profiler.listener, onKernelResponse]
 

--- a/Config/services/rest.yml
+++ b/Config/services/rest.yml
@@ -72,6 +72,11 @@ services:
         calls:
             - [setMetadataFactory, [@rest.metadata.factory]]
 
+    rest.listener.event_dispatcher:
+        class: BackBee\Rest\EventListener\EventDispatcherListener
+        calls:
+            - [setEventDispatcher, [@event.dispatcher]]
+
     rest.metadata.annotation_reader:
         class: Doctrine\Common\Annotations\AnnotationReader
 

--- a/Rest/EventListener/EventDispatcherListener.php
+++ b/Rest/EventListener/EventDispatcherListener.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Rest\EventListener;
+
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+use BackBee\Event\Event;
+use BackBee\Rest\Controller\AbstractRestController;
+
+/**
+ * EventDispatcherListener
+ *
+ * Dispatch a rest event like:
+ *
+ * Request: 'rest.controllername.actionname.request'
+ * Response: 'rest.controllername.actionname.response'
+ *
+ * @category    BackBee
+ *
+ * @author      f.kroockmann <florian.kroockmann@lp-digital.fr>
+ */
+class EventDispatcherListener
+{
+
+    private $eventDispatcher = null;
+
+    public function setEventDispatcher(EventDispatcher $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * onKernelController
+     *
+     * Dispatch event like 'rest.controllername.actionname.request'
+     * for the rest request only
+     *
+     * @param  FilterControllerEvent $event
+     */
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        if ($this->eventDispatcher === null) {
+            throw new \InvalidArgumentException(
+                'Event dispatcher not found, you must add it in "calls" argument in service file'
+            );
+        }
+
+        $request = $event->getRequest();
+        $controller = $event->getController();
+
+        if (!is_array($controller)) {
+            return;
+        }
+
+        if ($controller[0] instanceof AbstractRestController && isset($controller[1])) {
+
+            $eventName = $this->buildEventName(get_class($controller[0]), $controller[1], 'request');
+
+            if (null !== $eventName) {
+                $this->eventDispatcher->dispatch($eventName, new Event($event));
+            }
+        }
+    }
+
+    /**
+     * onKernelResponse
+     *
+     * Dispatch event like 'rest.controllername.actionname.response'
+     * for the rest request only
+     *
+     * @param  FilterResponseEvent $event
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if ($this->eventDispatcher === null) {
+            throw new \InvalidArgumentException(
+                'Event dispatcher not found, you must add it in "calls" argument in service file'
+            );
+        }
+
+        $request = $event->getRequest();
+        $response = $event->getResponse();
+
+        $controller = $request->attributes->get('_controller');
+        $action = $request->attributes->get('_action');
+
+        if (null !== $controller && null !== $action && class_exists($controller)) {
+            if (new $controller() instanceof AbstractRestController) {
+                $eventName = $this->buildEventName($controller, $action, 'response');
+
+                if (null !== $eventName) {
+                    $this->eventDispatcher->dispatch($eventName, new Event($event));
+                }
+            }
+        }
+    }
+
+    /**
+     * buildEventName
+     *
+     * Search the controller name in path like
+     * 'Backbee\Rest\Controller\FooController' => 'foo'
+     *
+     * And search the action name like
+     * 'barAction' => bar
+     *
+     * @param  [String] $controller
+     * @param  [String] $action
+     * @param  [String] $type
+     * @return [String|null]
+     */
+    private function buildEventName($controller, $action, $type)
+    {
+        $eventName = null;
+
+        preg_match("/(\w+)action$/i", $action, $actionMatches);
+        preg_match("/\\\\(\w+)controller$/i", $controller, $controllerMatches);
+
+        if (isset($actionMatches[1]) && isset($controllerMatches[1])) {
+            $eventName = strtolower('rest.' . $controllerMatches[1] . '.' . $actionMatches[1] . '.' . $type);
+        }
+
+        return $eventName;
+    }
+}

--- a/Rest/Tests/EventListener/EventDispatcherListenerTest
+++ b/Rest/Tests/EventListener/EventDispatcherListenerTest
@@ -1,0 +1,186 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Rest\Tests\EventListener;
+
+use BackBee\Controller\FrontController;
+
+use BackBee\Rest\EventListener\EventDispatcherListener;
+use BackBee\Rest\Tests\Fixtures\Controller\MockAbstractRestImplController;
+use BackBee\Rest\Tests\Fixtures\Controller\FixtureAnnotatedController;
+use BackBee\Rest\Tests\Fixtures\Listener\BasicListener;
+
+use BackBee\Tests\TestCase;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+/**
+ * Test for EventDispatchListener class.
+ *
+ * @category    BackBee
+ *
+ * @author      f.kroockmann <florian.kroockmann@lp-digital.fr>
+ *
+ * @coversDefaultClass \BackBee\Rest\EventListener\EventDispatcherListener
+ * @group Rest
+ */
+class EventDispatchListenerTest extends TestCase
+{
+    const REQUEST_EVENT_NAME = 'rest.mockabstractrestimpl.create404response.request';
+    const RESPONSE_EVENT_NAME = 'rest.mockabstractrestimpl.create404response.response';
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testThrowExceptionIfEventDispatcherDoesntExist()
+    {
+        $listener = new EventDispatcherListener();
+
+        $listener->onKernelController($this->getFilterControllerEvent());
+    }
+
+    public function testSetEventDispatcher()
+    {
+        $listener = new EventDispatcherListener();
+        $listener->setEventDispatcher($this->getBBApp()->getEventDispatcher());
+
+        $listener->onKernelController($this->getFilterControllerEvent());
+    }
+
+    public function testOnKernelController()
+    {
+        $eventDispatcher = $this->getBBApp()->getEventDispatcher();
+
+        $listener = new EventDispatcherListener();
+        $listener->setEventDispatcher($eventDispatcher);
+
+        $basicListener = new BasicListener();
+        $eventDispatcher->addListener($this::REQUEST_EVENT_NAME, array($basicListener, 'onListen'));
+
+        $this->assertFalse($basicListener->isListened());
+
+        $listener->onKernelController($this->getFilterControllerEvent());
+
+        $this->assertTrue($basicListener->isListened());
+    }
+
+    public function testOnKernelControllerWithNotRestController()
+    {
+        $eventDispatcher = $this->getBBApp()->getEventDispatcher();
+
+        $listener = new EventDispatcherListener();
+        $listener->setEventDispatcher($eventDispatcher);
+
+        $basicListener = new BasicListener();
+        $eventDispatcher->addListener($this::REQUEST_EVENT_NAME, array($basicListener, 'onListen'));
+
+        $this->assertFalse($basicListener->isListened());
+
+        $mockController = new FixtureAnnotatedController();
+        $action = 'defaultPaginationAction';
+
+        $controller = [$mockController, $action];
+        $event = new FilterControllerEvent(new FrontController(),
+                                           $controller,
+                                           $this->getRequest(get_class($mockController), $action),
+                                           FrontController::MASTER_REQUEST);
+
+        $listener->onKernelController($event);
+
+        $this->assertFalse($basicListener->isListened());
+    }
+
+    public function testOnKernelResponse()
+    {
+        $eventDispatcher = $this->getBBApp()->getEventDispatcher();
+
+        $listener = new EventDispatcherListener();
+        $listener->setEventDispatcher($eventDispatcher);
+
+        $basicListener = new BasicListener();
+        $eventDispatcher->addListener($this::RESPONSE_EVENT_NAME, array($basicListener, 'onListen'));
+
+        $this->assertFalse($basicListener->isListened());
+
+        $request = $this->getRequest(get_class(new MockAbstractRestImplController()), 'create404ResponseAction');
+        $event = new FilterResponseEvent(new FrontController(),
+                                         $request,
+                                         FrontController::MASTER_REQUEST,
+                                         $this->getResponse());
+
+        $listener->onKernelResponse($event);
+
+        $this->assertTrue($basicListener->isListened());
+    }
+
+    public function testOnKernelResponseWithNotRestController()
+    {
+        $eventDispatcher = $this->getBBApp()->getEventDispatcher();
+
+        $listener = new EventDispatcherListener();
+        $listener->setEventDispatcher($eventDispatcher);
+
+        $basicListener = new BasicListener();
+        $eventDispatcher->addListener($this::RESPONSE_EVENT_NAME, array($basicListener, 'onListen'));
+
+        $this->assertFalse($basicListener->isListened());
+
+        $request = $this->getRequest(get_class(new FixtureAnnotatedController()), 'defaultPaginationAction');
+        $event = new FilterResponseEvent(new FrontController(),
+                                         $request,
+                                         FrontController::MASTER_REQUEST,
+                                         $this->getResponse());
+
+        $listener->onKernelResponse($event);
+
+        $this->assertFalse($basicListener->isListened());
+    }
+
+    private function getFilterControllerEvent()
+    {
+        $mockController = new MockAbstractRestImplController();
+        $action = 'create404ResponseAction';
+
+        $controller = [$mockController, $action];
+        $request = $this->getRequest(get_class($mockController), $action);
+
+        return new FilterControllerEvent(new FrontController(), $controller, $request, FrontController::MASTER_REQUEST);
+    }
+
+    private function getRequest($controller, $action)
+    {
+        $request = Request::create('test', "POST", [], [], [], ['CONTENT_TYPE' => 'application/json']);
+        $request->attributes->set('_controller', $controller);
+        $request->attributes->set('_action', $action);
+
+        return $request;
+    }
+
+    private function getResponse()
+    {
+        return Response::create('content', 200);
+    }
+}

--- a/Rest/Tests/Fixtures/Listener/BasicListener.php
+++ b/Rest/Tests/Fixtures/Listener/BasicListener.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Rest\Tests\Fixtures\Listener;
+
+/**
+ * Basic Listener
+ *
+ * @category    BackBee
+ *
+ * @author      f.kroockmann <florian.kroockmann@lp-digital.fr>
+ */
+class BasicListener
+{
+    private $listened = false;
+
+    public function onListen()
+    {
+        $this->listened = true;
+    }
+
+    public function isListened()
+    {
+        return $this->listened;
+    }
+
+    public function reset()
+    {
+        $this->listened = false;
+    }
+}


### PR DESCRIPTION
If the controller extends AbstractRestController, an event is dispatched

For Request: 'rest.controllername.actionname.request'
For Response: 'rest.controllername.actionname.response'