### PR TITLE
[RFR]Creating bundleAdminUrl helper

### DIFF
--- a/Bundle/BundleControllerResolver.php
+++ b/Bundle/BundleControllerResolver.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Bundle;
+
+use BackBee\Bundle\Exception\BundleConfigurationException;
+use BackBee\DependencyInjection\ContainerInterface;
+
+/**
+ * @category    BackBee
+ *
+ * @author      Nicolas Dufreche <nicolas.dufreche@lp-digital.fr>
+ */
+class BundleControllerResolver
+{
+    private $container;
+
+    public function __construct(ContainerInterface $application)
+    {
+        $this->container = $container;
+    }
+
+    private function computeBundleName($name)
+    {
+        return str_replace('%bundle_name%', strtolower($name), BundleInterface::BUNDLE_SERVICE_ID_PATTERN);
+    }
+
+    /**
+     * Check if each parameters are correctly setted
+     *
+     * @param  string $bundle       bundle name
+     * @param  string $controller   controller name
+     * @param  string $action       action name
+     *
+     * @throws Exception            Bad configuration
+     */
+    private function resolve($bundle, $controller)
+    {
+        if (!$this->container->has($this->computeBundleName($bundle))) {
+            throw new BundleConfigurationException($bundle.' doesn\'t exists', BundleConfigurationException::BUNDLE_UNDLECLARED);
+        }
+
+        $config = $this->container->get($this->computeBundleName($bundle));
+
+        if (!isset($config['controller'])) {
+            throw new BundleConfigurationException('No controller definition in '.$bundle.' bundle configuration', BundleConfigurationException::CONTROLLER_SECTION_MISSING);
+        }
+
+        if (!isset($config['controller'][$controller])) {
+            throw new BundleConfigurationException($controller.' controller is undefinned in '.$bundle.' bundle configuration', BundleConfigurationException::CONTROLLER_UNDLECLARED);
+        }
+
+        return new {'\\'.$config['controller']['$controller']}($this->_renderer->getApplication());
+    }
+}

--- a/Bundle/Exception/BundleConfigurationException.php
+++ b/Bundle/Exception/BundleConfigurationException.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Bundle\Exception;
+
+use BackBee\Exception\BBException;
+
+/**
+ * Exception thrown if a bundle can not be loaded, init, started or ran.
+ *
+ * @category    BackBee
+ *
+ * @copyright   Lp digital system
+ * @author      Nicolas Dufreche <nicolas.dufreche@lp-digital.fr>
+ */
+class BundleConfigurationException extends BBException
+{
+    const BUNDLE_UNDLECLARED = 21000;
+    const CONTROLLER_SECTION_MISSING = 21001;
+    const CONTROLLER_UNDECLARED = 21002;
+
+    protected $_code = self::UNKNOWN_ERROR;
+}

--- a/Config/services/services.yml
+++ b/Config/services/services.yml
@@ -25,6 +25,7 @@ parameters:
     bbapp.console.command: bin/console.php
 
     bbapp.rest_api.path: /rest/
+    bbapp.rest_api.version: 1
 
     bbapp.dbal.logger.profiling.class: BackBee\Logging\DebugStackLogger
 

--- a/Renderer/Helper/bundleAdminUrl.php
+++ b/Renderer/Helper/bundleAdminUrl.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Renderer\Helper;
+
+use BackBee\Bundle\BundleControllerResolver;
+
+/**
+ * @category    BackBee
+ *
+ * @author      Nicolas Dufreche <nicolas.dufreche@lp-digital.fr>
+ */
+class bundleAdminUrl extends AbstractHelper
+{
+
+    /**
+     * @param  string   $route      route is composed by the bundle, controller and action name separated by a dot
+     * @param  array    $parameters optional parameters
+     * @param  array    $query      optional query parameters
+     *
+     * @return string               url
+     */
+    public function __invoke($route, Array $parameters = [], Array $query = [])
+    {
+        list($bundle, $controller, $action) = split('.', $route);
+
+        if ($this->_renderer->getApplication()->isDebugMode()) {
+            $this->checkParameters($bundle, $controller, $action);
+        }
+
+        $container = $this->_renderer->getApplication()->getContainer();
+
+        $url = $container->get('bbapp.rest_api.path').$container->get('bbapp.rest_api.version').'/bundle/'.$bundle.'/'.$controller.'/'.$action;
+
+        if (count($parameters) !== 0) {
+            $url = $url.'/'.implode('/', $parameters);
+        }
+
+        if (count($query) !== 0) {
+            $url = $url.'?'.implode('&', $query);
+        }
+
+        return $this->_renderer->getApplication()->getRouting()->getUri($url);
+    }
+
+    /**
+     * Check if each parameters are correctly setted
+     * @param  string $bundle       bundle name
+     * @param  string $controller   controller name
+     * @param  string $action       action name
+     *
+     * @throws Exception            Bad configuration
+     */
+    private function checkParameters($bundle, $controller, $action)
+    {
+        $container = $this->_renderer->getApplication()->getContainer();
+
+        $bundleController = (new BundleControllerResolver($container))->resolve($bundle, $controller);
+
+        if (!method_exists($bundleController, $action.'Action')) {
+            throw new \BadMethodCallException($bundleController.' doesn\'t have '.$action.'Action method', 1);
+        }
+    }
+}


### PR DESCRIPTION
This is an helper to generate easily bundle rest URL.

```twig
{{ this.bundleAdminUrl('demo.admin.index', {'id'},  {'optional': 'query'})|row }}
```

have to render `http://backbee.url/rest/1/bundle/demo/admin/index/id?optional=query`

To help the implementation when backbee is in debug mode we check all parameters if they are goodly defined