### PR TITLE
[RFR][Bundle] Add abstract bundle controller

### DIFF
--- a/Bundle/AbstractAdminBundleController.php
+++ b/Bundle/AbstractAdminBundleController.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Bundle;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ * @author Nicolas Dufreche <nicolas.dufreche@lp-digital.fr>
+ */
+abstract class AbstractAdminBundleController extends AbstractBundleController
+{
+    const NOTIFY_SUCCESS = 'success';
+    const NOTIFY_WARNING = 'warning';
+    const NOTIFY_ERROR = 'error';
+
+    /**
+     * @var array
+     */
+    protected $notifications = [];
+
+    protected $error;
+
+    /**
+     * @param $method
+     * @param $arguments
+     * @return mixed|Response
+     */
+    public function __call($method, $arguments)
+    {
+        if (!$this->isGranted('VIEW', $this->getBundle())) {
+            return $this->createResponse('You must be authenticated to access', 401);
+        }
+
+        try {
+            return parent::__call($method, $arguments);
+        } catch (\Exception $error) {
+            $this->notifyUser(self::NOTIFY_ERROR, $error->getMessage());
+
+            $completeResponse = [
+                'content' => '',
+                'notification' => $this->notifications,
+                'error' => [
+                    'name' => get_class($error),
+                    'message' => $error->getMessage(),
+                    'code' => $error->getCode(),
+                    'php_stack' => $error->getTraceAsString(),
+                ]
+            ];
+            return new JsonResponse($completeResponse, 500);
+        }
+    }
+
+    /**
+     * Notify the user with a message
+     * @param  String $type    values availble self::NOTIFY_SUCCESS, self::NOTIFY_WARNING and self::NOTIFY_ERROR
+     * @param  String $message Message to the user
+     */
+    public function notifyUser($type, $message)
+    {
+        $this->notifications[] = ['type' => $type, 'message' => $message];
+    }
+
+    /**
+     * @inherited
+     */
+    protected function decorateResponse($response, $method)
+    {
+        if (is_string($response)) {
+            $completeResponse = [
+                'content' => $response,
+                'notification' => $this->notifications,
+                'error' => '',
+            ];
+            $response =  new JsonResponse($completeResponse, 200);
+        }
+
+        if (!($response instanceof Response)) {
+            throw new \InvalidArgumentException(sprintf(
+                '%s must returns a string or an object instance of %s, %s given.',
+                get_class($this).'::'.$method,
+                'Symfony\Component\HttpFoundation\Response',
+                gettype($response)
+            ));
+        }
+        return $response;
+    }
+}

--- a/Bundle/AbstractBundle.php
+++ b/Bundle/AbstractBundle.php
@@ -308,6 +308,13 @@ abstract class AbstractBundle implements BundleInterface
             ;
         }
 
+        if (false !== property_exists($obj, 'admin_entry_point')) {
+            $entrieDefinition = explode('.', $obj->admin_entry_point);
+            $controller = $entrieDefinition[0];
+            $action = isset($entrieDefinition[1]) ? $entrieDefinition[1] : 'index';
+            $obj->admin_entry_point = (new BundleControllerResolver($this->application))->resolveBaseAdminUrl($obj->id, $controller, $action);
+        }
+
         $obj->exposed_actions = $this->getExposedActionsMapping();
 
         return $obj;

--- a/Bundle/AbstractBundleController.php
+++ b/Bundle/AbstractBundleController.php
@@ -1,0 +1,284 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Bundle;
+
+use BackBee\BBApplication;
+use BackBee\Bundle\AdminBundle\ValueProvider\ManageableProviderInterface;
+use BackBee\Controller\Controller;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Translation\Loader\YamlFileLoader;
+use Symfony\Component\Translation\Translator;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ * @author Nicolas Dufreche <nicolas.dufreche@lp-digital.fr>
+ */
+abstract class AbstractBundleController extends Controller
+{
+    /**
+     * @var \Symfony\Component\Translation\Translator
+     */
+    protected $translator;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var \BackBee\Routing\RouteCollection
+     */
+    protected $routing;
+
+    /**
+     * @var BundleInterface
+     */
+    protected $bundle;
+
+    public function __construct(BBApplication $app)
+    {
+        $this->logger = $app->getLogging();
+        $this->routing = $app->getRouting();
+
+        parent::__construct($app);
+    }
+
+    /**
+     * Set the current bundle
+     *
+     * @param BundleInterface $bundle
+     */
+    public function setBundle(BundleInterface $bundle)
+    {
+        $this->bundle = $bundle;
+    }
+
+    /**
+     * @param $method
+     * @param $arguments
+     * @return Response
+     */
+    public function __call($method, $arguments)
+    {
+        $method = $method.'Action';
+
+        if (true !== $methodExist = $this->checkMethodExist($method)) {
+            return $methodExist;
+        }
+
+        $result = $this->invockeAction($method, $arguments);
+
+        return $this->decorateResponse($result, $method);
+    }
+
+    /**
+     * Renders provided template with parameters and returns the generated string.
+     *
+     * @param  string     $template   the template relative path
+     * @param  array|null $parameters
+     * @return string
+     */
+    public function render($template, array $parameters = null, Response $response = null)
+    {
+        $parameters = array_merge([
+            'request'              => $this->getRequest(),
+            'routing'              => $this->routing,
+            'flash_bag'            => $this->application->getSession()->getFlashBag(),
+        ], $parameters ?: []);
+
+        return $this->application->getRenderer()->partial($template, $parameters);
+    }
+
+    /**
+     * Decorate response to be sure to get Response Object
+     *
+     * @param  String|Response  $response
+     * @param  String           $method   method called
+     * @return Response
+     * @throws \InvalidArgumentException
+     */
+    protected function decorateResponse($response, $method)
+    {
+        if (is_string($response)) {
+            $response = $this->createResponse($response);
+        }
+
+        if (!($response instanceof Response)) {
+            throw new \InvalidArgumentException(sprintf(
+                '%s must returns a string or an object instance of %s, %s given.',
+                get_class($this).'::'.$method,
+                'Symfony\Component\HttpFoundation\Response',
+                gettype($response)
+            ));
+        }
+
+        return $response;
+    }
+
+    /**
+     * Execute the controller method and return his response
+     *
+     * @param String    $method    method to call
+     * @param Array     $arguments method arguments
+     * @return String|Response
+     */
+    protected function invockeAction($method, $arguments)
+    {
+        try {
+            $result = call_user_func_array([$this, $method], $arguments);
+        } catch (\Exception $e) {
+            $result = $this->createResponse(
+                sprintf('%s::%s - %s:%s', get_class($this), $method, get_class($e), $e->getMessage()),
+                500
+            );
+        }
+        return $result;
+    }
+
+    /**
+     * check if the method exist
+     *
+     * @param  String   $method     method name
+     * @return true|Response
+     * @throws \LogicException
+     */
+    protected function checkMethodExist($method)
+    {
+        if (!method_exists($this, $method)) {
+            if ($this->application->isDebugMode()) {
+                return $this->createResponse(
+                    sprintf('Called undefined method: %s.', get_class($this).'::'.$method),
+                    500
+                );
+            } else {
+                throw new \LogicException(sprintf('Called undefined method: %s.', get_class($this).'::'.$method));
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Creates a Response object and returns it.
+     *
+     * @param  string  $content    the response body content (must be string)
+     * @param  integer $statusCode the response status code (default: 200)
+     * @return Response
+     */
+    protected function createResponse($content, $statusCode = 200, $contentType = 'text/html')
+    {
+        return new Response($content, $statusCode, ['Content-Type' => $contentType]);
+    }
+
+    /**
+     * Creates and returns an instance of RedirectResponse with provided url.
+     *
+     * @param  string $url The url to redirect the user to
+     * @param  int $statusCode The HTTP status code to return
+     * @return RedirectResponse
+     */
+    protected function redirect($url, $statusCode = 302)
+    {
+        return new RedirectResponse($url, $statusCode);
+    }
+
+    /**
+     * Returns the current session flash bag.
+     *
+     * @return \Symfony\Component\HttpFoundation\Session\Flash\FlashBag
+     */
+    protected function getFlashBag()
+    {
+        return $this->application->getSession()->getFlashBag();
+    }
+
+    /**
+     * Adds a success message to the session flashbag.
+     *
+     * @param string $message
+     *
+     * @return AbstractBundleController
+     */
+    protected function addFlashSuccess($message)
+    {
+        $this->application->getSession()->getFlashBag()->add('success', $message);
+
+        return $this;
+    }
+
+    /**
+     * Adds a error message to the session flashbag.
+     *
+     * @param string $message
+     *
+     * @return AbstractBundleController
+     */
+    protected function addFlashError($message)
+    {
+        $this->application->getSession()->getFlashBag()->add('error', $message);
+
+        return $this;
+    }
+
+    /**
+     * Returns translator.
+     *
+     * @return Translator
+     */
+    private function getTranslator()
+    {
+        return $this->getContainer()->get('translator');
+    }
+
+    /**
+     * Returns an entity repository
+     *
+     * @return \Doctrine\ORM\EntityRepository
+     */
+    public function getRepository($entity)
+    {
+        return $this->getEntityManager()->getRepository($entity);
+    }
+
+    /**
+     * Tries to get entity with provided identifier and throws exception if not found.
+     *
+     * Note that you should not provide namespace prefix (=BackBee\Bundle\AdminBundle\Entity).
+     *
+     * @param  string $entityName The entity namespace
+     * @param  string $id         The identifier to find
+     * @return object
+     * @throws \InvalidArgumentException if cannot find entity with provided identifier
+     */
+    protected function throwsExceptionIfEntityNotFound($entityName, $id)
+    {
+        if (null === $entity = $this->getRepository($entityName)->find($id)) {
+            throw new \InvalidArgumentException(sprintf('Cannot find `%s` with id `%s`.', $entityName, $id));
+        }
+
+        return $entity;
+    }
+}

--- a/Bundle/BundleControllerResolver.php
+++ b/Bundle/BundleControllerResolver.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Bundle;
+
+use BackBee\Bundle\Exception\BundleConfigurationException;
+use BackBee\ApplicationInterface;
+
+/**
+ * @category    BackBee
+ *
+ * @author      Nicolas Dufreche <nicolas.dufreche@lp-digital.fr>
+ */
+class BundleControllerResolver
+{
+    /**
+     * @var ApplicationInterface
+     */
+    private $application;
+    /**
+     * @var \BackBee\DependencyInjection\ContainerInterface
+     */
+    private $container;
+
+    public function __construct(ApplicationInterface $application)
+    {
+        $this->application = $application;
+        $this->container = $application->getContainer();
+    }
+
+    /**
+     * Compute the service identifier bundle name
+     *
+     * @param  String $name
+     * @return String
+     */
+    private function computeBundleName($name)
+    {
+        return str_replace('%bundle_name%', strtolower($name), BundleInterface::BUNDLE_SERVICE_ID_PATTERN);
+    }
+
+    /**
+     * Resolve the bundle controller by passing two identifier (bundle and controller) and return it.
+     *
+     * @param  String $bundle       Bundle identifier used to declare it into bundle.yml
+     * @param  String $controller   Controller identifier used to declare it inte your bundle configuration
+     * @return \BackBee\Bundle\AbstractBundleController
+     *
+     * @throws Exception            Bad configuration
+     */
+    public function resolve($bundle, $controller)
+    {
+        if (!$this->container->has($this->computeBundleName($bundle))) {
+            throw new BundleConfigurationException($bundle.' doesn\'t exists', BundleConfigurationException::BUNDLE_UNDECLARED);
+        }
+
+        $config = $this->container->get($this->computeBundleName($bundle))->getProperty();
+
+        if (!isset($config['admin_controller'])) {
+            throw new BundleConfigurationException('No controller definition in '.$bundle.' bundle configuration', BundleConfigurationException::CONTROLLER_SECTION_MISSING);
+        }
+
+        if (!isset($config['admin_controller'][$controller])) {
+            throw new BundleConfigurationException($controller.' controller is undefinned in '.$bundle.' bundle configuration', BundleConfigurationException::CONTROLLER_UNDECLARED);
+        }
+        $namespace = '\\'.$config['admin_controller'][$controller];
+        return new $namespace($this->application);
+    }
+
+    /**
+     * Compute the minimal Admin Base Url
+     *
+     * @param  String $bundleId     Bundle identifier used to declare it into bundle.yml
+     * @param  String $controllerId Controller identifier used to declare it inte your bundle configuration
+     * @param  String $actionId     Action identifier refere to a method name like "indexAction" into the controller without the Action keyword
+     * @return String               Base URL to contact an bundle admin action
+     */
+    public function resolveBaseAdminUrl($bundleId, $controllerId, $actionId)
+    {
+        return str_replace(
+            [
+                '%bundle_id%',
+                '%controller_id%',
+                '%action_id%',
+            ],
+            [
+                $bundleId,
+                $controllerId,
+                $actionId,
+            ],
+            BundleInterface::BUNDLE_ADMIN_URL_PATTERN
+        );
+    }
+}

--- a/Bundle/BundleInterface.php
+++ b/Bundle/BundleInterface.php
@@ -40,6 +40,7 @@ interface BundleInterface extends ObjectIdentifiableInterface, \JsonSerializable
      */
     const BUNDLE_SERVICE_ID_PATTERN = 'bundle.%bundle_name%';
     const CONFIG_SERVICE_ID_PATTERN = '%bundle_service_id%.config';
+    const BUNDLE_ADMIN_URL_PATTERN = '/bundle/%bundle_id%/%controller_id%/%action_id%';
 
     /**
      * Config directories names.

--- a/Bundle/Exception/BundleConfigurationException.php
+++ b/Bundle/Exception/BundleConfigurationException.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Bundle\Exception;
+
+use BackBee\Exception\BBException;
+
+/**
+ * Exception thrown if a bundle can not be loaded, init, started or ran.
+ *
+ * @category    BackBee
+ *
+ * @copyright   Lp digital system
+ * @author      Nicolas Dufreche <nicolas.dufreche@lp-digital.fr>
+ */
+class BundleConfigurationException extends BBException
+{
+    const BUNDLE_UNDECLARED = 21000;
+    const CONTROLLER_SECTION_MISSING = 21001;
+    const CONTROLLER_UNDECLARED = 21002;
+    const ADMIN_ROUTE_BADLY_INVOKED = 21003;
+
+    protected $_code = self::UNKNOWN_ERROR;
+}

--- a/Config/route.yml
+++ b/Config/route.yml
@@ -545,15 +545,15 @@ bb.rest.bundle.patch:
         _method: PATCH
 
 bb.rest.bundle.exposed_actions:
-    pattern: /rest/{version}/bundle/{bundle_name}/{controller_name}/{action_name}{parameters}
+    pattern: /rest/{version}/bundle/{bundleName}/{controllerName}/{actionName}{parameters}
     defaults:
         _action: accessBundleExposedRoutesAction
         _controller: BackBee\Rest\Controller\BundleController
     requirements:
         version: \d+
-        bundle_name: "[a-z]+"
-        controller_name: "[a-z]+"
-        action_name: "[a-z]+"
+        bundleName: "[a-z]+"
+        controllerName: "[a-z]+"
+        actionName: "[a-z]+"
         parameters: "^\/.+|"
 
 bb.rest.media_folder.get_collection:

--- a/Config/services/services.yml
+++ b/Config/services/services.yml
@@ -25,6 +25,7 @@ parameters:
     bbapp.console.command: bin/console.php
 
     bbapp.rest_api.path: /rest/
+    bbapp.rest_api.version: 1
 
     bbapp.dbal.logger.profiling.class: BackBee\Logging\DebugStackLogger
 

--- a/Renderer/Helper/bundleAdminForm.php
+++ b/Renderer/Helper/bundleAdminForm.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Renderer\Helper;
+
+use BackBee\Bundle\BundleControllerResolver;
+use BackBee\Bundle\Exception\BundleConfigurationException;
+
+/**
+ * @category    BackBee
+ *
+ * @author      Nicolas Dufreche <nicolas.dufreche@lp-digital.fr>
+ */
+class bundleAdminForm extends bundleAdminUrl
+{
+
+    /**
+     * @param  string   $route      route is composed by the bundle, controller and action name separated by a dot
+     * @param  array    $query      optional url parameters and query parameters
+     * @param  string   $httpMethod http method
+     *
+     * @return string               url
+     */
+    public function __invoke($route, Array $query = [], $httpMethod = 'POST')
+    {
+        $url = parent::__invoke($route, $query);
+
+        return 'data-bundle="form" action="'.$url.'" data-http-method="'.$this->getJsMethod($httpMethod).'" method="'.$httpMethod.'"';
+    }
+}

--- a/Renderer/Helper/bundleAdminLink.php
+++ b/Renderer/Helper/bundleAdminLink.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Renderer\Helper;
+
+use BackBee\Bundle\BundleControllerResolver;
+use BackBee\Bundle\Exception\BundleConfigurationException;
+
+/**
+ * @category    BackBee
+ *
+ * @author      Nicolas Dufreche <nicolas.dufreche@lp-digital.fr>
+ */
+class bundleAdminLink extends bundleAdminUrl
+{
+
+    /**
+     * @param  string   $route      route is composed by the bundle, controller and action name separated by a dot
+     * @param  array    $query      optional url parameters and query parameters
+     * @param  string   $httpMethod http method
+     *
+     * @return string               url
+     */
+    public function __invoke($route, Array $query = [], $httpMethod = 'GET')
+    {
+        $url = parent::__invoke($route, $query);
+
+        return 'data-bundle="link" href="'.$url.'" data-http-method="'.$this->getJsMethod($httpMethod).'"';
+    }
+}

--- a/Renderer/Helper/bundleAdminUrl.php
+++ b/Renderer/Helper/bundleAdminUrl.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Renderer\Helper;
+
+use BackBee\Bundle\BundleControllerResolver;
+use BackBee\Bundle\Exception\BundleConfigurationException;
+
+/**
+ * @category    BackBee
+ *
+ * @author      Nicolas Dufreche <nicolas.dufreche@lp-digital.fr>
+ */
+class bundleAdminUrl extends AbstractHelper
+{
+
+    /**
+     * @param  string   $route      route is composed by the bundle, controller and action name separated by a dot
+     * @param  array    $query      optional url parameters and query parameters
+     *
+     * @return string               url
+     */
+    public function __invoke($route, Array $query = [])
+    {
+        $route = explode('.', $route);
+
+        if (count($route) != 3) {
+            throw new BundleConfigurationException('Route definition is not well formated '.implode('.', $route), BundleConfigurationException::ADMIN_ROUTE_BADLY_INVOKED);
+        }
+
+        list($bundle, $controller, $action) = $route;
+
+        $application = $this->_renderer->getApplication();
+
+        if ($application->isDebugMode()) {
+            $this->checkParameters($bundle, $controller, $action);
+        }
+
+        $url = (new BundleControllerResolver($application))->resolveBaseAdminUrl($bundle, $controller, $action);
+
+        $url .= $this->parseQueryParameters($bundle, $controller, $action, $query);
+
+        return $url;
+    }
+
+    /**
+     * parse query parameters to build the end of the url
+     *
+     * @param  String $bundle
+     * @param  String $controller
+     * @param  String $action
+     * @param  Array  $query
+     *
+     * @return String
+     */
+    private function parseQueryParameters($bundle, $controller, $action, $query)
+    {
+        $url = '';
+
+        if (0 !== count($query)) {
+            $controller = (new BundleControllerResolver($this->_renderer->getApplication()))->resolve($bundle, $controller);
+
+            $methodParameters = (new \ReflectionMethod($controller, $action.'Action'))->getParameters();
+
+            $parameters = [];
+
+            foreach ($methodParameters as $value) {
+                if (!in_array($value->name, $query)) {
+                    $parameters[$value->name] = $query[$value->name];
+                    unset($query[$value->name]);
+                }
+            }
+
+            if (count($parameters) !== 0) {
+                $url .= '/'.implode('/', $parameters);
+            }
+
+            if (count($query) !== 0) {
+                foreach ($query as $key => $value) {
+                    $query[$key] = $key.'='.$value;
+                }
+                $url .= $url.'?'.implode('&', $query);
+            }
+        }
+
+        return $url;
+    }
+
+    /**
+     * Do the correspondence behind js method and http methods
+     *
+     * @param  String $method
+     * @return String
+     */
+    protected function getJsMethod($method)
+    {
+        $methods = [
+            'get' => 'read',
+            'post' => 'create',
+            'put' => 'update',
+            'delete' => 'delete',
+        ];
+        return isset($methods[strtolower($method)]) ? $methods[strtolower($method)] : 'read';
+    }
+
+    /**
+     * Check if each parameters are correctly setted
+     *
+     * @param  string $bundle       bundle name
+     * @param  string $controller   controller name
+     * @param  string $action       action name
+     *
+     * @throws Exception            Bad configuration
+     */
+    private function checkParameters($bundle, $controller, $action)
+    {
+        $application = $this->_renderer->getApplication();
+
+        $bundleController = (new BundleControllerResolver($application))->resolve($bundle, $controller);
+
+        if (!method_exists($bundleController, $action.'Action')) {
+            throw new \BadMethodCallException($bundleController.' doesn\'t have '.$action.'Action method', 1);
+        }
+    }
+}


### PR DESCRIPTION
The admin interface system, to help developer to ease develop bundle interface.

It's composed of:
- abstract bundle controller to automatize routing system
- 3 helper to build her admin URL by passing the bundle name, controller name and action name.
  - `bundleAdminUrl` url générator
  - `bundleAdminLink` add all html properties at your link to automated interactions
  - `bundleAdminForm` same as bundleAdminLink but for forms
- `BundleControllerResolver` it's a new class to interact with bundle controller by passing just bundle name and controller name
- An upgrade of `accessBundleExposedRoutesAction` from `Rest\BundleController`
- And new configuration available to the bundle config file like
  - `admin_controller` is an array how to declare your's controller
  - `admin_entry_point` the entry point of the bundle administration

To see the first implementation of this system => backbee/DemoBundle#19