### PR TITLE
[DependencyInjection] updated the way we handle service that depends on factory

### DIFF
--- a/Config/services/services.yml
+++ b/Config/services/services.yml
@@ -80,8 +80,7 @@ services:
 
     request:
         class: %bbapp.request.class%
-        factory_class: %bbapp.request.class%
-        factory_method: createFromGlobals
+        factory: [%bbapp.request.class%, createFromGlobals]
 
     controller:
         class:      %bbapp.controller.class%
@@ -235,8 +234,7 @@ services:
 
     doctrine.connection.default:
         class: Doctrine\DBAL\Connection
-        factory_service: em
-        factory_method: getConnection
+        factory: [@em, getConnection]
 
     doctrine:
         class: BackBee\Doctrine\Registry

--- a/DependencyInjection/BootstrapResolver.php
+++ b/DependencyInjection/BootstrapResolver.php
@@ -58,7 +58,7 @@ class BootstrapResolver
      *
      * @var string
      */
-    private $base_dir;
+    private $baseDir;
 
     /**
      * application's context.
@@ -77,13 +77,13 @@ class BootstrapResolver
     /**
      * BootstrapResolver's constructor.
      *
-     * @param string $base_dir    base directory from where we define in which directory to look into
+     * @param string $baseDir     base directory from where we define in which directory to look into
      * @param string $context     application's context
      * @param string $environment application's environment
      */
-    public function __construct($base_dir, $context, $environment)
+    public function __construct($baseDir, $context, $environment)
     {
-        $this->base_dir = $base_dir;
+        $this->baseDir = $baseDir;
         $this->context = null === $context ? BBApplication::DEFAULT_CONTEXT : $context;
         $this->environment = null === $environment ? BBApplication::DEFAULT_ENVIRONMENT : $environment;
     }
@@ -98,24 +98,24 @@ class BootstrapResolver
      */
     public function getBootstrapParameters()
     {
-        $bootstrap_filepath = null;
+        $bootstrapFilepath = null;
 
-        $directories = BootstrapDirectory::getDirectories($this->base_dir, $this->context, $this->environment);
+        $directories = BootstrapDirectory::getDirectories($this->baseDir, $this->context, $this->environment);
         foreach ($directories as $directory) {
-            $bootstrap_filepath = $directory.DIRECTORY_SEPARATOR.self::BOOTSTRAP_FILENAME;
-            if (true === is_file($bootstrap_filepath) && true === is_readable($bootstrap_filepath)) {
+            $bootstrapFilepath = $directory.DIRECTORY_SEPARATOR.self::BOOTSTRAP_FILENAME;
+            if (is_file($bootstrapFilepath) && is_readable($bootstrapFilepath)) {
                 break;
             }
 
-            $bootstrap_filepath = null;
+            $bootstrapFilepath = null;
         }
 
-        if (null === $bootstrap_filepath) {
+        if (null === $bootstrapFilepath) {
             throw new BootstrapFileNotFoundException($directories);
         }
 
-        $parameters = Yaml::parse($bootstrap_filepath);
-        $parameters['bootstrap_filepath'] = $bootstrap_filepath;
+        $parameters = Yaml::parse(file_get_contents($bootstrapFilepath));
+        $parameters['bootstrap_filepath'] = $bootstrapFilepath;
 
         return $parameters;
     }

--- a/DependencyInjection/Tests/BootstrapResolverTest.php
+++ b/DependencyInjection/Tests/BootstrapResolverTest.php
@@ -40,62 +40,15 @@ class BootstrapResolverTest extends \PHPUnit_Framework_TestCase
      *
      * @var string
      */
-    private $resources_base_dir;
+    private $resourcesBaseDir;
 
     /**
      * define the test resources directory.
      */
     public function setUp()
     {
-        $this->resources_base_dir = __DIR__.'/BootstrapResolverTest_Resources';
+        $this->resourcesBaseDir = __DIR__.'/BootstrapResolverTest_Resources';
     }
-
-    /**
-     * Test BootstrapResolver::getBootstrapPotentialsDirectories(), the number and the order of
-     * directory this method returns.
-     */
-    /*public function testGetBootstrapPotentialsDirectories()
-    {
-        $context = 'api';
-        $environment = 'preprod';
-
-        // test WITHOUT context and WITHOUT environment
-        $bootstrap_resolver = new BootstrapResolver(__DIR__, null, null);
-        $directories = array(
-            0 => __DIR__ . DIRECTORY_SEPARATOR . 'Config'
-        );
-
-        $this->assertEquals($directories, $bootstrap_resolver->getBootstrapPotentialsDirectories());
-
-        // test WITHOUT context and WITH environment
-        $bootstrap_resolver = new BootstrapResolver(__DIR__, null, $environment);
-        $directories = array(
-            0 => __DIR__ . DIRECTORY_SEPARATOR . 'Config' . DIRECTORY_SEPARATOR . $environment,
-            1 => __DIR__ . DIRECTORY_SEPARATOR . 'Config'
-        );
-
-        $this->assertEquals($directories, $bootstrap_resolver->getBootstrapPotentialsDirectories());
-
-        // test WITH context and WITHOUT environment
-        $bootstrap_resolver = new BootstrapResolver(__DIR__, $context, null);
-        $directories = array(
-            0 => implode(DIRECTORY_SEPARATOR, array(__DIR__, $context, 'Config')),
-            1 => __DIR__ . DIRECTORY_SEPARATOR . 'Config'
-        );
-
-        $this->assertEquals($directories, $bootstrap_resolver->getBootstrapPotentialsDirectories());
-
-        // test WITH context and WITH environment
-        $bootstrap_resolver = new BootstrapResolver(__DIR__, $context, $environment);
-        $directories = array(
-            0 => implode(DIRECTORY_SEPARATOR, array(__DIR__, $context, 'Config', $environment)),
-            1 => implode(DIRECTORY_SEPARATOR, array(__DIR__, $context, 'Config')),
-            2 => __DIR__ . DIRECTORY_SEPARATOR . 'Config' . DIRECTORY_SEPARATOR . $environment,
-            3 => __DIR__ . DIRECTORY_SEPARATOR . 'Config'
-        );
-
-        $this->assertEquals($directories, $bootstrap_resolver->getBootstrapPotentialsDirectories());
-    }*/
 
     /**
      * test raise of BootstrapFileNotFoundException by providing wrong base directory to BootstrapResolver's
@@ -103,7 +56,7 @@ class BootstrapResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testRaiseBootstrapFileNotFoundException()
     {
-        $bootstrap_resolver = new BootstrapResolver($this->resources_base_dir.'/Config', null, null);
+        $bootstrap_resolver = new BootstrapResolver($this->resourcesBaseDir.'/Config', null, null);
 
         try {
             $bootstrap_resolver->getBootstrapParameters();
@@ -123,45 +76,45 @@ class BootstrapResolverTest extends \PHPUnit_Framework_TestCase
         $environment = 'preprod';
 
         // test to get bootstrap parameters WITHOUT context and WITHOUT environment
-        $bootstrap_resolver = new BootstrapResolver($this->resources_base_dir, null, null);
+        $bootstrap_resolver = new BootstrapResolver($this->resourcesBaseDir, null, null);
         $this->assertEquals(
             array(
                 'context'            => 'default',
                 'environment'        => '',
-                'bootstrap_filepath' => $this->resources_base_dir.'/Config/bootstrap.yml',
+                'bootstrap_filepath' => $this->resourcesBaseDir.'/Config/bootstrap.yml',
             ),
             $bootstrap_resolver->getBootstrapParameters()
         );
 
         // test to get bootstrap parameters WITH context and WITH environment
-        $bootstrap_resolver = new BootstrapResolver($this->resources_base_dir, $context, $environment);
+        $bootstrap_resolver = new BootstrapResolver($this->resourcesBaseDir, $context, $environment);
         $this->assertEquals(
             array(
                 'context'            => 'api',
                 'environment'        => 'preprod',
-                'bootstrap_filepath' => $this->resources_base_dir.'/api/Config/preprod/bootstrap.yml',
+                'bootstrap_filepath' => $this->resourcesBaseDir.'/api/Config/preprod/bootstrap.yml',
             ),
             $bootstrap_resolver->getBootstrapParameters()
         );
 
         // test to get bootstrap parameters WITH context and WITHOUT environment
-        $bootstrap_resolver = new BootstrapResolver($this->resources_base_dir, $context, null);
+        $bootstrap_resolver = new BootstrapResolver($this->resourcesBaseDir, $context, null);
         $this->assertEquals(
             array(
                 'context'            => 'api',
                 'environment'        => '',
-                'bootstrap_filepath' => $this->resources_base_dir.'/api/Config/bootstrap.yml',
+                'bootstrap_filepath' => $this->resourcesBaseDir.'/api/Config/bootstrap.yml',
             ),
             $bootstrap_resolver->getBootstrapParameters()
         );
 
         // test to get bootstrap parameters WITHOUT context and WITH environment
-        $bootstrap_resolver = new BootstrapResolver($this->resources_base_dir, null, $environment);
+        $bootstrap_resolver = new BootstrapResolver($this->resourcesBaseDir, null, $environment);
         $this->assertEquals(
             array(
                 'context'            => 'default',
                 'environment'        => 'preprod',
-                'bootstrap_filepath' => $this->resources_base_dir.'/Config/preprod/bootstrap.yml',
+                'bootstrap_filepath' => $this->resourcesBaseDir.'/Config/preprod/bootstrap.yml',
             ),
             $bootstrap_resolver->getBootstrapParameters()
         );

--- a/DependencyInjection/Tests/ContainerProxyTest.php
+++ b/DependencyInjection/Tests/ContainerProxyTest.php
@@ -48,119 +48,100 @@ class ContainerProxyTest extends \PHPUnit_Framework_TestCase
 {
     const RANDOM_SERVICE_NEW_SIZE_VALUE = 42;
 
-    /**
-     * [$container description].
-     *
-     * @var [type]
-     */
     private $container;
-
-    /**
-     * [$services_yml_array description].
-     *
-     * @var array
-     */
-    private $services_array;
 
     /**
      * setup the environment for test.
      */
     public function setUp()
     {
-        $this->services_yml_array = array(
-            'parameters' => array(
+        $servicesYmlArray = [
+            'parameters' => [
                 'service.class' => 'BackBee\DependencyInjection\Tests\RandomService',
                 'size_one'      => 300,
                 'size_two'      => 8000,
                 'size_three'    => 44719,
-            ),
-            'services'   => array(
-                'service_one' => array(
+            ],
+            'services'   => [
+                'service_one' => [
                     'class'     => '%service.class%',
-                    'arguments' => array('%size_two%'),
-                ),
-                'service_two' => array(
+                    'arguments' => ['%size_two%'],
+                ],
+                'service_two' => [
                     'class'     => '%service.class%',
-                    'calls'     => array(
-                        array('setSize', array('%size_three%')),
-                    ),
-                    'tags'  => array(
-                        array('name' => 'dumpable'),
-                    ),
-                ),
-                'service_three' => array(
+                    'calls'     => [
+                        ['setSize', ['%size_three%']],
+                    ],
+                    'tags'  => [
+                        ['name' => 'dumpable'],
+                    ],
+                ],
+                'service_three' => [
                     'class'     => '%service.class%',
-                    'calls'     => array(
-                        array('setClassProxy', array('')),
-                    ),
-                    'tags'  => array(
-                        array('name' => 'dumpable'),
-                    ),
-                ),
-                'service_four' => array(
+                    'calls'     => [
+                        ['setClassProxy', ['']],
+                    ],
+                    'tags'  => [
+                        ['name' => 'dumpable'],
+                    ],
+                ],
+                'service_four' => [
                     'class' => '%service.class%',
-                    'tags'  => array(
-                        array('name' => 'foo'),
-                        array('name' => 'bar'),
-                    ),
-                ),
-                'service_five' => array(
+                    'tags'  => [
+                        ['name' => 'foo'],
+                        ['name' => 'bar'],
+                    ],
+                ],
+                'service_five' => [
                     'synthetic' => true,
-                ),
-                'service_six' => array(
+                ],
+                'service_six' => [
                     'class'  => '%service.class%',
                     'public' => false,
-                ),
-                'service_seven' => array(
+                ],
+                'service_seven' => [
                     'class'        => '%service.class%',
                     'scope'        => 'prototype',
                     'file'         => '/foo/bar',
-                    'configurator' => array('@service_six', 'getSize'),
-                ),
-                'service_eight' => array(
-                    'class'          => '%service.class%',
-                    'factory_class'  => '/foo/bar/ServiceFactory',
-                    'factory_method' => 'get',
-                ),
-                'service_nine' => array(
-                    'class'           => '%service.class%',
-                    'factory_service' => 'service_zero',
-                    'factory_method'  => 'get',
-                ),
-                'service_ten' => array(
+                    'configurator' => ['@service_six', 'getSize'],
+                ],
+                'service_eight' => [
+                    'class'   => '%service.class%',
+                    'factory' => ['\DateTime', 'getLastErrors'],
+                ],
+                'service_nine' => [
+                    'class'   => '%service.class%',
+                    'factory' => ['@service_zero', 'get'],
+                ],
+                'service_ten' => [
                     'abstract' => true,
-                    'calls'    => array(
-                        array('setSize', array(8)),
-                    ),
-                ),
-                'service_eleven' => array(
+                    'calls'    => [
+                        ['setSize', [8]],
+                    ],
+                ],
+                'service_eleven' => [
                     'class'  => '%service.class%',
                     'parent' => 'service_ten',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $this->container = new Container();
 
-        vfsStream::setup('directory', 0777, array(
-            'services.yml' => Yaml::dump($this->services_yml_array),
-        ));
+        vfsStream::setup('directory', 0777, [
+            'services.yml' => Yaml::dump($servicesYmlArray),
+        ]);
 
         ServiceLoader::loadServicesFromYamlFile($this->container, vfsStream::url('directory'));
-
         $this->container->get('service_two')->setSize(self::RANDOM_SERVICE_NEW_SIZE_VALUE);
-        // $this->container->get('service_three');
     }
 
-    /**
-     * @covers ::__construct
-     */
     public function testGetParameter()
     {
         $dumper = new PhpArrayDumper($this->container);
 
         $container = new ContainerProxy();
-        $container->init(unserialize($dumper->dump(array('do_compile' => false))));
+        $container->init(unserialize($dumper->dump(['do_compile' => false])));
 
         $this->assertEquals($this->container->getParameterBag()->all(), $container->getParameterBag()->all());
 
@@ -168,15 +149,6 @@ class ContainerProxyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::get
-     * @covers ::tryLoadDefinitionFromRaw
-     * @covers ::tryRestoreDumpableService
-     * @covers ::buildDefinition
-     * @covers ::setDefinitionClass
-     * @covers ::setDefinitionArguments
-     * @covers ::convertArgument
-     *
      * @depends testGetParameter
      */
     public function testGet(ContainerInterface $container)
@@ -192,14 +164,6 @@ class ContainerProxyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::get
-     * @covers ::tryLoadDefinitionFromRaw
-     * @covers ::tryRestoreDumpableService
-     * @covers ::setDefinitionTags
-     * @covers ::setDefinitionMethodCalls
-     * @covers ::convertArgument
-     *
      * @depends testGet
      */
     public function testTryRestoreDumpableService(ContainerInterface $container)
@@ -228,10 +192,6 @@ class ContainerProxyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::has
-     * @covers ::tryLoadDefinitionFromRaw
-     *
      * @depends testTryRestoreDumpableService
      */
     public function testHas(ContainerInterface $container)
@@ -255,10 +215,6 @@ class ContainerProxyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::hasDefinition
-     * @covers ::tryLoadDefinitionFromRaw
-     *
      * @depends testHas
      */
     public function testHasDefinition(ContainerInterface $container)
@@ -282,20 +238,6 @@ class ContainerProxyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::getDefinition
-     * @covers ::tryLoadDefinitionFromRaw
-     * @covers ::buildDefinition
-     * @covers ::setDefinitionTags
-     * @covers ::setDefinitionProperties
-     * @covers ::setDefinitionFactoryClass
-     * @covers ::setDefinitionFactoryService
-     * @covers ::setDefinitionFactoryMethod
-     * @covers ::setDefinitionConfigurator
-     * @covers ::convertArgument
-     *
-     * @covers ::loadRawDefinitions
-     *
      * @depends testHasDefinition
      */
     public function testGetDefinition(ContainerInterface $container)
@@ -331,10 +273,13 @@ class ContainerProxyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('getSize', $configurator[1]);
 
         // Test restoration of service factory class, factory service and factory method
-        $this->assertEquals($container->getDefinition('service_eight')->getFactoryClass(), '/foo/bar/ServiceFactory');
-        $this->assertEquals($container->getDefinition('service_eight')->getFactoryMethod(), 'get');
-        $this->assertEquals($container->getDefinition('service_nine')->getFactoryService(), 'service_zero');
-        $this->assertEquals($container->getDefinition('service_nine')->getFactoryMethod(), 'get');
+        $factory = $container->getDefinition('service_eight')->getFactory();
+        $this->assertEquals('\DateTime', $factory[0]);
+        $this->assertEquals('getLastErrors', $factory[1]);
+
+        $factory = $container->getDefinition('service_nine')->getFactory();
+        $this->assertEquals('service_zero', $factory[0]->__toString());
+        $this->assertEquals('get', $factory[1]);
 
         // Test restoration of service with parent (without compilation)
         $this->assertTrue($container->hasDefinition('service_ten'));
@@ -361,9 +306,6 @@ class ContainerProxyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($parent_method_calls, $container->getDefinition('service_eleven')->getMethodCalls());
     }
 
-    /**
-     * @covers ::isCompiled
-     */
     public function testIsCompiled()
     {
         // test that ContainerProxy::isCompiled return false value

--- a/DependencyInjection/Tests/Dumper/PhpArrayDumperTest.php
+++ b/DependencyInjection/Tests/Dumper/PhpArrayDumperTest.php
@@ -68,7 +68,7 @@ class PhpArrayDumperTest extends \PHPUnit_Framework_TestCase
      *
      * @var array
      */
-    private $raw_services;
+    private $rawServices;
 
     /**
      * setup the environment for test.
@@ -77,27 +77,24 @@ class PhpArrayDumperTest extends \PHPUnit_Framework_TestCase
     {
         $this->container = new Container();
         $this->dumper = new PhpArrayDumper($this->container);
-        $config_test_directory = realpath(__DIR__.'/PhpArrayDumperTest_Resources');
+        $configTestDir = realpath(__DIR__.'/PhpArrayDumperTest_Resources');
 
-        if (false === is_dir($config_test_directory)) {
-            throw new \Exception(sprintf('Unable to find test Config directory (%s)', $config_test_directory));
+        if (!is_dir($configTestDir)) {
+            throw new \Exception(sprintf('Unable to find test Config directory (%s)', $configTestDir));
         }
 
-        $services_filepath = $config_test_directory.DIRECTORY_SEPARATOR.'services.yml';
-        if (false === is_file($services_filepath) || false === is_readable($services_filepath)) {
-            throw new \Exception(sprintf('Unable to find or read services.yml (%s)', $services_filepath));
+        $servicesFilepath = $configTestDir.DIRECTORY_SEPARATOR.'services.yml';
+        if (!is_file($servicesFilepath) || !is_readable($servicesFilepath)) {
+            throw new \Exception(sprintf('Unable to find or read services.yml (%s)', $servicesFilepath));
         }
 
-        $this->raw_services = Yaml::parse($services_filepath);
+        $this->rawServices = Yaml::parse(file_get_contents($servicesFilepath));
 
-        ServiceLoader::loadServicesFromYamlFile($this->container, $config_test_directory);
+        ServiceLoader::loadServicesFromYamlFile($this->container, $configTestDir);
 
         $this->dump = unserialize($this->dumper->dump());
     }
 
-    /**
-     * @covers ::dump
-     */
     public function testDumpBase()
     {
         $this->assertTrue(is_array($this->dump));
@@ -108,87 +105,65 @@ class PhpArrayDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('is_compiled', $this->dump));
     }
 
-    /**
-     * @covers ::dump
-     * @covers ::dumpContainerParameters
-     */
     public function testDumpContainerParameters()
     {
-        $this->assertEquals($this->raw_services['parameters'], $this->dump['parameters']);
+        $this->assertEquals($this->rawServices['parameters'], $this->dump['parameters']);
     }
 
-    /**
-     * @covers ::dump
-     * @covers ::dumpContainerDefinitions
-     * @covers ::convertDefinitionToPhpArray
-     * @covers ::hydrateDefinitionClass
-     * @covers ::hydrateDefinitionArguments
-     * @covers ::hydrateDefinitionTags
-     * @covers ::hydrateDefinitionMethodCalls
-     * @covers ::convertArgument
-     */
     public function testDumpContainerBasicsDefinitions()
     {
         $this->assertTrue(array_key_exists('france.brazil.date', $this->dump['services']));
-        $this->assertTrue(array_key_exists('france.brazil.date', $this->raw_services['services']));
+        $this->assertTrue(array_key_exists('france.brazil.date', $this->rawServices['services']));
 
         // Test definition's class
         $this->assertTrue(array_key_exists('class', $this->dump['services']['france.brazil.date']));
-        $this->assertTrue(array_key_exists('class', $this->raw_services['services']['france.brazil.date']));
+        $this->assertTrue(array_key_exists('class', $this->rawServices['services']['france.brazil.date']));
         $this->assertEquals(
             $this->dump['services']['france.brazil.date']['class'],
-            $this->raw_services['services']['france.brazil.date']['class']
+            $this->rawServices['services']['france.brazil.date']['class']
         );
 
         // Test definition's arguments
         $this->assertTrue(array_key_exists('arguments', $this->dump['services']['france.brazil.date']));
-        $this->assertTrue(array_key_exists('arguments', $this->raw_services['services']['france.brazil.date']));
+        $this->assertTrue(array_key_exists('arguments', $this->rawServices['services']['france.brazil.date']));
         $this->assertEquals(
             $this->dump['services']['france.brazil.date']['arguments'],
-            $this->raw_services['services']['france.brazil.date']['arguments']
+            $this->rawServices['services']['france.brazil.date']['arguments']
         );
 
         // Test definition's tags
         $this->assertTrue(array_key_exists('tags', $this->dump['services']['france.brazil.date']));
-        $this->assertTrue(array_key_exists('tags', $this->raw_services['services']['france.brazil.date']));
+        $this->assertTrue(array_key_exists('tags', $this->rawServices['services']['france.brazil.date']));
         $this->assertEquals(
             $this->dump['services']['france.brazil.date']['tags'],
-            $this->raw_services['services']['france.brazil.date']['tags']
+            $this->rawServices['services']['france.brazil.date']['tags']
         );
 
         // Test definition's calls
         $this->assertTrue(array_key_exists('calls', $this->dump['services']['france.brazil.date']));
-        $this->assertTrue(array_key_exists('calls', $this->raw_services['services']['france.brazil.date']));
+        $this->assertTrue(array_key_exists('calls', $this->rawServices['services']['france.brazil.date']));
         $this->assertEquals(
             $this->dump['services']['france.brazil.date']['calls'],
-            $this->raw_services['services']['france.brazil.date']['calls']
+            $this->rawServices['services']['france.brazil.date']['calls']
         );
     }
 
-    /**
-     * @covers ::dumpContainerAliases
-     * @covers ::convertDefinitionToPhpArray
-     */
     public function testDumpContainerAliases()
     {
         $this->assertTrue(array_key_exists('alias.test', $this->dump['aliases']));
-        $this->assertTrue(array_key_exists('alias.test', $this->raw_services['services']));
-        $this->assertTrue(array_key_exists('alias', $this->raw_services['services']['alias.test']));
+        $this->assertTrue(array_key_exists('alias.test', $this->rawServices['services']));
+        $this->assertTrue(array_key_exists('alias', $this->rawServices['services']['alias.test']));
 
         $this->assertEquals(
-            $this->raw_services['services']['alias.test']['alias'],
+            $this->rawServices['services']['alias.test']['alias'],
             $this->dump['aliases']['alias.test']
         );
     }
 
-    /**
-     * @covers ::hydrateDefinitionScopeProperty
-     * @covers ::convertDefinitionToPhpArray
-     */
     public function testHydrateDefinitionScopeProperty()
     {
         $this->assertEquals(
-            $this->raw_services['services']['service_scope_prototype']['scope'],
+            $this->rawServices['services']['service_scope_prototype']['scope'],
             $this->dump['services']['service_scope_prototype']['scope']
         );
 
@@ -196,14 +171,10 @@ class PhpArrayDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(array_key_exists('scope', $this->dump['services']['service_scope_container']));
     }
 
-    /**
-     * @covers ::hydrateDefinitionPublicProperty
-     * @covers ::convertDefinitionToPhpArray
-     */
     public function testHydrateDefinitionPublicProperty()
     {
         $this->assertEquals(
-            $this->raw_services['services']['service_public_false']['public'],
+            $this->rawServices['services']['service_public_false']['public'],
             $this->dump['services']['service_public_false']['public']
         );
 
@@ -211,60 +182,35 @@ class PhpArrayDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(array_key_exists('public', $this->dump['services']['service_public_true']));
     }
 
-    /**
-     * @covers ::hydrateDefinitionFileProperty
-     * @covers ::convertDefinitionToPhpArray
-     */
     public function testHydrateDefinitionFileProperty()
     {
         $this->assertEquals(
-            $this->raw_services['services']['service_with_file']['file'],
+            $this->rawServices['services']['service_with_file']['file'],
             $this->dump['services']['service_with_file']['file']
         );
     }
 
-    /**
-     * @covers ::hydrateDefinitionFactoryClass
-     * @covers ::hydrateDefinitionFactoryService
-     * @covers ::hydrateDefinitionFactoryMethod
-     * @covers ::convertDefinitionToPhpArray
-     */
     public function testContainerDumpFactoryServiceAndClassAndMethod()
     {
         // Test factory class
         $this->assertEquals(
-            $this->raw_services['services']['service_factory_class']['factory_class'],
-            $this->dump['services']['service_factory_class']['factory_class']
-        );
-
-        $this->assertEquals(
-            $this->raw_services['services']['service_factory_class']['factory_method'],
-            $this->dump['services']['service_factory_class']['factory_method']
+            $this->rawServices['services']['service_factory_class']['factory'],
+            $this->dump['services']['service_factory_class']['factory']
         );
 
         // Test factory service
         $this->assertEquals(
-            $this->raw_services['services']['service_factory_service']['factory_service'],
-            $this->dump['services']['service_factory_service']['factory_service']
-        );
-
-        $this->assertEquals(
-            $this->raw_services['services']['service_factory_service']['factory_method'],
-            $this->dump['services']['service_factory_service']['factory_method']
+            $this->rawServices['services']['service_factory_service']['factory'],
+            $this->dump['services']['service_factory_service']['factory']
         );
     }
 
-    /**
-     * @covers ::hydrateDefinitionAbstractProperty
-     * @covers ::hydrateDefinitionParent
-     * @covers ::convertDefinitionToPhpArray
-     */
     public function testContainerDumpParentAndChildService()
     {
         // Test parent service
         $this->assertTrue($this->dump['services']['datetime_manager']['abstract']);
         $this->assertEquals(
-            $this->raw_services['services']['datetime_manager']['abstract'],
+            $this->rawServices['services']['datetime_manager']['abstract'],
             $this->dump['services']['datetime_manager']['abstract']
         );
 
@@ -274,29 +220,22 @@ class PhpArrayDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(array_key_exists('abstract', $this->dump['services']['datetime_with_parent']));
 
         $this->assertEquals(
-            $this->raw_services['services']['datetime_with_parent']['parent'],
+            $this->rawServices['services']['datetime_with_parent']['parent'],
             $this->dump['services']['datetime_with_parent']['parent']
         );
     }
 
-    /**
-     * @covers ::hydrateDefinitionConfigurator
-     * @covers ::convertDefinitionToPhpArray
-     */
     public function testhydrateDefinitionConfigurator()
     {
         $this->assertTrue(array_key_exists('service.use.configurator', $this->dump['services']));
-        $this->assertTrue(array_key_exists('service.use.configurator', $this->raw_services['services']));
+        $this->assertTrue(array_key_exists('service.use.configurator', $this->rawServices['services']));
 
         $this->assertEquals(
-            $this->raw_services['services']['service.use.configurator']['configurator'],
+            $this->rawServices['services']['service.use.configurator']['configurator'],
             $this->dump['services']['service.use.configurator']['configurator']
         );
     }
 
-    /**
-     * @covers ::dumpDumpableServices
-     */
     public function testDumpableService()
     {
         $config_service_id = 'config';
@@ -334,7 +273,7 @@ class PhpArrayDumperTest extends \PHPUnit_Framework_TestCase
 
         $restore_call_args = null;
         foreach ($dump['services'][$config_service_id]['calls'] as $call) {
-            if (true === isset($call[0]) && 'restore' === $call[0]) {
+            if (isset($call[0]) && 'restore' === $call[0]) {
                 $restore_call_args = $call[1];
             }
         }
@@ -342,7 +281,7 @@ class PhpArrayDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($restore_call_args);
         $this->assertTrue(
             2 === count($restore_call_args)
-            && true === isset($restore_call_args[0])
+            && isset($restore_call_args[0])
             && isset($restore_call_args[1])
         );
 
@@ -368,9 +307,6 @@ class PhpArrayDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null !== $config_container, $config_dump['has_container']);
     }
 
-    /**
-     * @covers ::dumpDumpableServices
-     */
     public function testNotDumpableService()
     {
         $id = 'not.dumpable_service';
@@ -391,13 +327,10 @@ class PhpArrayDumperTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers ::dump
-     */
     public function testDumpContainerCompile()
     {
         $this->assertFalse($this->dump['is_compiled']);
-        $this->dump = unserialize($this->dumper->dump(array('do_compile' => true)));
+        $this->dump = unserialize($this->dumper->dump(['do_compile' => true]));
         $this->assertTrue($this->dump['is_compiled']);
         $this->assertTrue($this->container->isFrozen());
     }

--- a/DependencyInjection/Tests/Dumper/PhpArrayDumperTest_Resources/services.yml
+++ b/DependencyInjection/Tests/Dumper/PhpArrayDumperTest_Resources/services.yml
@@ -43,14 +43,12 @@ services:
         file: /var/foo/bar
     service_factory_class:
         class: \DateTime
-        factory_class: \FooBar\DateTimeFactory
-        factory_method: get
+        factory: [\FooBar\DateTimeFactory, get]
     fake_service_datetime_factory:
         class: \FooBar\DateTimeFactory
     service_factory_service:
         class: \DateTime
-        factory_service: fake_service_datetime_factory
-        factory_method: get
+        factory: [@fake_service_datetime_factory, get]
     datetime_manager:
         abstract: true
         calls:

--- a/Stream/ClassWrapper/Adapter/Yaml.php
+++ b/Stream/ClassWrapper/Adapter/Yaml.php
@@ -344,7 +344,7 @@ class Yaml extends AbstractClassWrapper
             }
 
             try {
-                $yamlDatas = parserYaml::parse($this->_path);
+                $yamlDatas = parserYaml::parse(file_get_contents($this->_path));
             } catch (ParseException $e) {
                 throw new ClassWrapperException($e->getMessage());
             }


### PR DESCRIPTION
``Symfony\Component\DependencyInjection\Definition::[get|set]Factory[Method|Class|Service]()`` are now deprecated so this PR updated it to be compliant with this. This also improves:

- Remaining deprecation notices drop from ``43688`` to ``9267``
- Other deprecation notices drop from ``551`` to ``137``