### PR TITLE
[RFR] [Renderer] Renderer can now handle custom config per adapter #480

### DIFF
--- a/Config/renderer.yml
+++ b/Config/renderer.yml
@@ -5,8 +5,12 @@ bb_scripts_directory:
     form: %bbapp.base.dir%/Form/Templates/scripts
 
 adapter:
-    - BackBee\Renderer\Adapter\Twig
-    - BackBee\Renderer\Adapter\phtml
+    twig:
+        class: BackBee\Renderer\Adapter\Twig
+        config: []
+    phtml:
+        class: BackBee\Renderer\Adapter\phtml
+        config: []
 
 path:
     scriptdir: Templates/scripts

--- a/Renderer/AbstractRendererAdapter.php
+++ b/Renderer/AbstractRendererAdapter.php
@@ -46,7 +46,7 @@ abstract class AbstractRendererAdapter implements RendererAdapterInterface
      *
      * @param AbstractRenderer $renderer
      */
-    public function __construct(AbstractRenderer $renderer)
+    public function __construct(AbstractRenderer $renderer, array $config = [])
     {
         $this->renderer = $renderer;
     }

--- a/Renderer/Adapter/phtml.php
+++ b/Renderer/Adapter/phtml.php
@@ -48,7 +48,10 @@ class phtml extends AbstractRendererAdapter
      *
      * @var array
      */
-    protected $includeExtensions = array('.phtml', '.php');
+    protected $includeExtensions = [
+        '.phtml',
+        '.php',
+    ];
 
     /**
      * @var array
@@ -61,14 +64,14 @@ class phtml extends AbstractRendererAdapter
     private $vars;
 
     /**
-     * @param AbstractRenderer $renderer [description]
+     * @param AbstractRenderer $renderer
      */
-    public function __construct(AbstractRenderer $renderer)
+    public function __construct(AbstractRenderer $renderer, array $config = [])
     {
-        parent::__construct($renderer);
+        parent::__construct($renderer, $config);
 
-        $this->params = array();
-        $this->vars = array();
+        $this->params = [];
+        $this->vars = [];
     }
 
     /**
@@ -131,7 +134,7 @@ class phtml extends AbstractRendererAdapter
         return is_readable($filename);
     }
 
-    public function renderTemplate($filename, array $templateDir, array $params = array(), array $vars = array())
+    public function renderTemplate($filename, array $templateDir, array $params = [], array $vars = [])
     {
         foreach ($params as $key => $v) {
             $this->setParam($key, $v);
@@ -168,13 +171,13 @@ class phtml extends AbstractRendererAdapter
      */
     public function assign($var, $value = null)
     {
-        if (true === is_string($var)) {
+        if (is_string($var)) {
             $this->vars[$var] = $value;
 
             return $this;
         }
 
-        if (true === is_array($var)) {
+        if (is_array($var)) {
             foreach ($var as $key => $value) {
                 $this->vars[$key] = $value;
             }
@@ -192,13 +195,13 @@ class phtml extends AbstractRendererAdapter
      */
     public function setParam($param, $value = null)
     {
-        if (true === is_string($param)) {
+        if (is_string($param)) {
             $this->params[$param] = $value;
 
             return $this;
         }
 
-        if (true === is_array($param)) {
+        if (is_array($param)) {
             foreach ($param as $key => $value) {
                 $this->params[$key] = $value;
             }

--- a/Renderer/RendererAdapterInterface.php
+++ b/Renderer/RendererAdapterInterface.php
@@ -40,7 +40,7 @@ interface RendererAdapterInterface
      *
      * @param AbstractRenderer $renderer
      */
-    public function __construct(AbstractRenderer $renderer);
+    public function __construct(AbstractRenderer $renderer, array $config = []);
 
     /**
      * Returns array that contains every single file's extension managed by this adapter.

--- a/Renderer/Tests/Adapter/TwigTest.php
+++ b/Renderer/Tests/Adapter/TwigTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Renderer\Tests\Adapter;
+
+use BackBee\Renderer\Tests\Mock\TwigAdapter as Twig;
+use BackBee\Renderer\Renderer;
+use BackBee\Tests\BackBeeTestCase;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ */
+class TwigTest extends BackBeeTestCase
+{
+    public function testPassingConfigToConstructor()
+    {
+        $renderer = new Renderer(self::$app);
+        $twig = new Twig($renderer);
+        $this->assertFalse($twig->getEngine()->isStrictVariables());
+
+        $twig = new Twig($renderer, [
+            'strict_variables' => true,
+        ]);
+        $this->assertTrue($twig->getEngine()->isStrictVariables());
+    }
+}

--- a/Renderer/Tests/Mock/FakeRendererAdapter.php
+++ b/Renderer/Tests/Mock/FakeRendererAdapter.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Renderer\Tests\Mock;
+
+use BackBee\Renderer\AbstractRenderer;
+use BackBee\Renderer\AbstractRendererAdapter;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ */
+class FakeRendererAdapter extends AbstractRendererAdapter
+{
+    private $config;
+
+    public function __construct(AbstractRenderer $renderer, array $config = [])
+    {
+        $this->config = $config;
+    }
+
+    public function getAdapterConfig()
+    {
+        return $this->config;
+    }
+
+    public function getManagedFileExtensions()
+    {
+        return ['.test'];
+    }
+}

--- a/Renderer/Tests/Mock/TwigAdapter.php
+++ b/Renderer/Tests/Mock/TwigAdapter.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Renderer\Tests\Mock;
+
+use BackBee\Renderer\Adapter\Twig;
+
+/**
+ * Extends BackBee\Renderer\Adapter\Twig to add ::getEngine() method which is required for tests.
+ *
+ * @author Eric Chau
+ */
+class TwigAdapter extends Twig
+{
+    public function getEngine()
+    {
+        return $this->twig;
+    }
+}

--- a/Renderer/Tests/RendererTest.php
+++ b/Renderer/Tests/RendererTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Renderer\Tests;
+
+use BackBee\Renderer\Renderer;
+use BackBee\Tests\BackBeeTestCase;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ */
+class RendererTest extends BackBeeTestCase
+{
+    private static $originalRendererConfig;
+
+    public static function setUpBeforeClass()
+    {
+        self::$originalRendererConfig = self::$app->getConfig()->getRendererConfig();
+    }
+
+    public function testSupportsOfAdaptersConfigOldAndNewFormat()
+    {
+        $config = self::$app->getConfig();
+
+        $resetAdapterConfig = self::$originalRendererConfig;
+        $resetAdapterConfig['adapter'] = [];
+        $config->setSection('renderer', $resetAdapterConfig, true);
+
+        $renderer = new Renderer(self::$app);
+        $this->assertCount(0, $renderer->getAdapters());
+
+        $oldandNewFormat = self::$originalRendererConfig;
+        $oldandNewFormat['adapter'] = [
+            'twig' => [
+                'class' => 'BackBee\Renderer\Adapter\Twig',
+            ],
+            'BackBee\Renderer\Adapter\phtml',
+        ];
+
+        $config->setSection('renderer', $oldandNewFormat, true);
+        $renderer = new Renderer(self::$app);
+        $this->assertCount(2, $renderer->getAdapters());
+        $this->assertSame('.twig', $renderer->getDefaultAdapterExt());
+
+        $adaptersClass = [
+            'twig'  => 'BackBee\Renderer\Adapter\Twig',
+            'phtml' => 'BackBee\Renderer\Adapter\phtml',
+        ];
+        foreach ($renderer->getAdapters() as $key => $adapter) {
+            $this->assertInstanceOf($adaptersClass[$key], $adapter);
+        }
+    }
+
+    public function testPassingAdapterConfig()
+    {
+        $config = self::$app->getConfig();
+
+        $fakeAdapterConfig = [
+            'foo'  => 'bar',
+            'fake' => true,
+        ];
+        $adapterConfig = self::$originalRendererConfig;
+        $adapterConfig['adapter'] = [
+            'BackBee\Renderer\Adapter\phtml',
+            'test' => [
+                'class'  => 'BackBee\Renderer\Tests\Mock\FakeRendererAdapter',
+                'config' => $fakeAdapterConfig,
+            ],
+        ];
+
+        $config->setSection('renderer', $adapterConfig, true);
+        $renderer = new Renderer(self::$app);
+        $this->assertInstanceOf('BackBee\Renderer\Tests\Mock\FakeRendererAdapter', $renderer->getAdapterByExt('test'));
+        $this->assertSame($fakeAdapterConfig, $renderer->getAdapterByExt('test')->getAdapterConfig());
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$app->getConfig()->setSection('renderer', self::$originalRendererConfig, true);
+    }
+}


### PR DESCRIPTION
According to issue #480, this PR aims to resolve this by allowing ``BackBee\Renderer\Renderer`` to handle and pass to each adapters its custom configurations.

Note that this improvement support old and new version of adapters config declaration:

```yml
# old version, renderer.yml
adapter: [\BackBee\Renderer\Adapter\Twig, \BackBee\Renderer\Adapter\phml]
```

new version: 

```yml
# new version, renderer.yml
adapter: 
    twig:
        class: \BackBee\Renderer\Adapter\Twig
        config: 
            autoescape: false
    phtml:
        class: \BackBee\Renderer\Adapter\phml
        config: [] # this entry is optional
```

A mix of both format is also supported =)