### PR TITLE
[RFR] [Renderer] added 'translator' to bb variable

### DIFF
--- a/Renderer/Renderer.php
+++ b/Renderer/Renderer.php
@@ -1086,10 +1086,11 @@ class Renderer extends AbstractRenderer implements DumpableServiceInterface, Dum
     {
         return [
             'bb' => [
-                'debug' => $this->getApplication()->isDebugMode(),
-                'token' => $this->getApplication()->getBBUserToken(),
-                'request' => $this->getApplication()->getRequest(),
-                'routing' => $this->getApplication()->getRouting(),
+                'debug'      => $this->getApplication()->isDebugMode(),
+                'token'      => $this->getApplication()->getBBUserToken(),
+                'request'    => $this->getApplication()->getRequest(),
+                'routing'    => $this->getApplication()->getRouting(),
+                'translator' => $this->getApplication()->getContainer()->get('translator'),
             ],
         ];
     }


### PR DESCRIPTION
This PR aims to ease access to application's translator into Renderer templates. Example in twig template:

- Before: ``{{ this.getApplication().getContainer().get('translator').trans('random_token') }}``
- Now: ``{{ bb.translator.trans('random_token') }}``

ping @ndufreche.