### PR TITLE
Debug toolbar is now available when error page

### DIFF
--- a/Resources/scripts/Profiler/panel.html.twig
+++ b/Resources/scripts/Profiler/panel.html.twig
@@ -19,18 +19,22 @@
 
 <style>
     #bb-profiler-panel{
-        height: 30px;
-        border-top: 1px;
-        background-color: #F7F7F7;
-        font: 11px Verdana,Arial,sans-serif;
-        border-top: 1px solid #ccc;
-        bottom: 0;
-        left: 0;
-        margin: 0;
         position: fixed;
+        background-color: #f7f7f7;
+        left: 0;
         right: 0;
+        margin: 0;
+        padding: 0 40px 0 0;
+        z-index: 6000000;
+        font: 11px Verdana, Arial, sans-serif;
         text-align: left;
-        z-index: 100000;
+        color: #2f2f2f;
+        background-image: -moz-linear-gradient(top, #e4e4e4, #ffffff);
+        background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#e4e4e4), to(#ffffff));
+        background-image: -o-linear-gradient(top, #e4e4e4, #ffffff);
+        background: linear-gradient(top, #e4e4e4, #ffffff);
+        bottom: 0;
+        border-top: 1px solid #bbb;
     }
 
     #bb-profiler-close {

--- a/Resources/scripts/Profiler/toolbar.html.twig
+++ b/Resources/scripts/Profiler/toolbar.html.twig
@@ -75,6 +75,18 @@
         padding: 2px 4px;
     }
 
+    #bb-profiler-panel .nav a{
+        color: black !important;
+        display: block;
+        font-weight: normal;
+        text-decoration: none;
+        margin: 0;
+        padding: 2px 4px;
+        min-width: 20px;
+        text-align: center;
+        vertical-align: middle;
+    }
+
     #bb-profiler-panel .nav a:hover{
         background-color: #fff;
     }


### PR DESCRIPTION
When page is in 404 or 500 error, we don't have any information from debug toolbar.

This pull request activate toolbar when we display the Symfony debug response.
![debug-toolbar](https://cloud.githubusercontent.com/assets/1247388/8458601/45bdef02-2018-11e5-9d09-14d561547810.png)

The UI is not perfect yet but this ask a refactoring of our debug toolbar (which is out of scope of the issue solved by this contribution).

Edit: I've added some styles, we may need a  new UI.
![capture2](https://cloud.githubusercontent.com/assets/1247388/8459195/d2338bce-201b-11e5-80c4-fe9b244a9f1c.png)


