### PR TITLE
[Console] updated every bundle command

### DIFF
--- a/Bundle/Event/BundleInstallUpdateEvent.php
+++ b/Bundle/Event/BundleInstallUpdateEvent.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Bundle\Event;
+
+use BackBee\Bundle\BundleInterface;
+use BackBee\Event\Event;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ */
+class BundleInstallUpdateEvent extends Event
+{
+    private $bundle;
+    private $forced;
+    private $logs;
+
+    /**
+     * Creates an instance of BundleInstallUpdateEvent.
+     *
+     * @param  BundleInterface $target
+     * @param  mixed           $eventArgs
+     * @throws \InvalidArgumentException if the provided target does not implement BackBee\Bundle\BundleInterface
+     */
+    public function __construct($target, $eventArgs = null)
+    {
+        if (!($target instanceof BundleInterface)) {
+            throw new \InvalidArgumentException(
+                'Target of bundle update or action event must be instance of BackBee\Bundle\BundleInterface'
+            );
+        }
+
+        parent::__construct($target, $eventArgs);
+        $this->bundle = $target;
+        $this->forced = isset($eventArgs['force']) ? (boolean) $eventArgs['force'] : false;
+        $this->logs = isset($eventArgs['logs']) ? (array) $eventArgs['logs'] : [];
+    }
+
+    /**
+     * Returns the bundle which is updating.
+     *
+     * @return
+     */
+    public function getBundle()
+    {
+        return $this->bundle;
+    }
+
+    /**
+     * Returns true if current update action is forced, else false.
+     *
+     * @return boolean
+     */
+    public function isForced()
+    {
+        return $this->forced;
+    }
+
+    /**
+     * Adds new message to logs.
+     *
+     * @param string $key
+     * @param string $message
+     * @return self
+     * @throws \InvalidArgumentException if message argument is not type of string
+     */
+    public function addLog($key, $message)
+    {
+        if (!is_string($message)) {
+            throw new \InvalidArgumentException(sprintf(
+                '[%s]: "message" must be type of string, %s given.',
+                __METHOD__,
+                gettype($message)
+            ));
+        }
+
+        if (!isset($this->logs[$key])) {
+            $this->logs[$key] = [];
+        }
+
+        $this->logs[$key][] = $message;
+
+        return $this;
+    }
+
+    /**
+     * Returns bundle update logs.
+     *
+     * @return array
+     */
+    public function getLogs()
+    {
+        return $this->logs;
+    }
+}

--- a/Console/Command/AbstractBundleCommand.php
+++ b/Console/Command/AbstractBundleCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Console\Command;
+
+use BackBee\Bundle\BundleInterface;
+use BackBee\Console\AbstractCommand;
+use BackBee\DependencyInjection\ContainerInterface;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @category    BackBee
+ * @copyright   Lp digital system
+ * @author      Eric Chau <eric.chau@lp-digital.fr>
+ */
+abstract class AbstractBundleCommand extends AbstractCommand
+{
+    const INSTALL_COMMAND = 'install';
+    const UPDATE_COMMAND = 'update';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $name = strtr($input->getArgument('name'), '/', '\\');
+
+        if (!$this->getContainer()->has('bundle.'.$name)) {
+            throw new \InvalidArgumentException(sprintf('Not a valid bundle: %s', $name));
+        }
+
+        $bundle = $this->getContainer()->get('bundle.'.$name);
+
+        $this->doExecute($bundle, $input->getOption('force'), $this->getCommandType().'Bundle', $output);
+    }
+
+    protected function doExecute(BundleInterface $bundle, $force, $methodToCall, OutputInterface $output)
+    {
+        $starttime = microtime(true);
+        $message = null;
+
+        if ($force) {
+            $message = "\n\n".sprintf(
+                ' ✓  %s of bundle "%s" started.',
+                ucfirst($this->getCommandType()),
+                $bundle->getId()
+            )."\n\n";
+        } else {
+            $message = "\n\n".sprintf(
+                ' ✓  Getting information about %s of bundle "%s"...',
+                $this->getCommandType(),
+                $bundle->getId()
+            )."\n\n";
+        }
+
+        $output->writeln($message);
+
+        $logs = $this->getContainer()->get('bundle.loader')->$methodToCall($bundle, $force);
+
+        if ($force) {
+            $output->writeln(sprintf(
+                ' ✓  %s of bundle "%s" completed in %s.',
+                ucfirst($this->getCommandType()),
+                $bundle->getId(),
+                number_format(microtime(true) - $starttime, 3).' s'
+            )."\n\n");
+        }
+
+        $output->writeln('SQL:'.(0 < count($logs['sql']) ? '' : ' -'));
+        foreach ($logs['sql'] as $sql) {
+            $output->writeln($sql);
+        }
+
+        unset($logs['sql']);
+
+        foreach ($logs as $key => $other) {
+            foreach ((array) $other as $message) {
+                $output->writeln(sprintf('[%s] %s', ucfirst($key), $message));
+            }
+        }
+    }
+
+    /**
+     * Returns self::INSTALL_COMMAND (="install") or self::UPDATE_COMMAND to specify its type.
+     *
+     * @return string
+     */
+    abstract protected function getCommandType();
+}

--- a/Console/Command/BundleInstallAllCommand.php
+++ b/Console/Command/BundleInstallAllCommand.php
@@ -27,17 +27,14 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use BackBee\Console\AbstractCommand;
-
 /**
  * Install all bundles command.
  *
  * @category    BackBee
- *
  * @copyright   Lp digital system
- * @author      k.golovin
+ * @author      Eric Chau <eric.chau@lp-digital.fr>
  */
-class BundleInstallAllCommand extends AbstractCommand
+class BundleInstallAllCommand extends AbstractBundleCommand
 {
     /**
      * {@inheritdoc}
@@ -63,20 +60,18 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $force = $input->getOption('force');
+        $methodToCall = $this->getCommandType().'Bundle';
 
-        $bbapp = $this->getContainer()->get('bbapp');
-
-        foreach ($bbapp->getBundles() as $bundle) {
-            $output->writeln('Installing bundle: '.$bundle->getId().'');
-
-            $sqls = $bundle->getCreateQueries($bundle->getBundleEntityManager());
-
-            if ($force) {
-                $output->writeln('<info>Running install</info>');
-                $bundle->install();
-            }
-
-            $output->writeln('<info>SQL executed: </info>'.PHP_EOL.implode(";".PHP_EOL, $sqls).'');
+        foreach ($this->getContainer()->get('bbapp')->getBundles() as $bundle) {
+            $this->doExecute($bundle, $force, $methodToCall, $output);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getCommandType()
+    {
+        return AbstractBundleCommand::INSTALL_COMMAND;
     }
 }

--- a/Console/Command/BundleInstallCommand.php
+++ b/Console/Command/BundleInstallCommand.php
@@ -24,11 +24,7 @@
 namespace BackBee\Console\Command;
 
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
-
-use BackBee\Console\AbstractCommand;
 
 /**
  * Install bundle command.
@@ -36,9 +32,9 @@ use BackBee\Console\AbstractCommand;
  * @category    BackBee
  *
  * @copyright   Lp digital system
- * @author      k.golovin
+ * @author      Eric Chau <eric.chau@lp-digital.fr>
  */
-class BundleInstallCommand extends AbstractCommand
+class BundleInstallCommand extends AbstractBundleCommand
 {
     /**
      * {@inheritdoc}
@@ -62,30 +58,8 @@ EOF
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function getCommandType()
     {
-        $name = strtr($input->getArgument('name'), '/', '\\');
-
-        $force = $input->getOption('force');
-
-        $bbapp = $this->getContainer()->get('bbapp');
-
-        $bundle = $bbapp->getBundle($name);
-        /* @var $bundle \BackBee\Bundle\AbstractBundle */
-
-        if (null === $bundle) {
-            throw new \InvalidArgumentException(sprintf("Not a valid bundle: %s", $name));
-        }
-
-        $output->writeln('Installing bundle: '.$bundle->getId().'');
-
-        $sqls = $bundle->getCreateQueries($bundle->getBundleEntityManager());
-
-        if ($force) {
-            $output->writeln('<info>Running install</info>');
-            $bundle->install();
-        }
-
-        $output->writeln('<info>SQL executed: </info>'.PHP_EOL.implode(";".PHP_EOL, $sqls).'');
+        return AbstractBundleCommand::INSTALL_COMMAND;
     }
 }

--- a/Console/Command/BundleUpdateAllCommand.php
+++ b/Console/Command/BundleUpdateAllCommand.php
@@ -27,17 +27,14 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use BackBee\Console\AbstractCommand;
-
 /**
  * Update all bundles command.
  *
  * @category    BackBee
- *
  * @copyright   Lp digital system
- * @author      k.golovin
+ * @author      Eric Chau <eric.chau@lp-digital.fr>
  */
-class BundleUpdateAllCommand extends AbstractCommand
+class BundleUpdateAllCommand extends AbstractBundleCommand
 {
     /**
      * {@inheritdoc}
@@ -47,7 +44,7 @@ class BundleUpdateAllCommand extends AbstractCommand
         $this
             ->setName('bundle:update_all')
             ->addOption('force', null, InputOption::VALUE_NONE, 'The update SQL will be executed against the DB')
-            ->setDescription('Updates a bundle')
+            ->setDescription('Updates all bundles')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> updates all bundles:
 
@@ -63,21 +60,18 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $force = $input->getOption('force');
+        $methodToCall = $this->getCommandType().'Bundle';
 
-        $bbapp = $this->getContainer()->get('bbapp');
-
-        foreach ($bbapp->getBundles() as $bundle) {
-            $output->writeln('Updating bundle: '.$bundle->getId().'');
-
-            $sqls = $bundle->getUpdateQueries($bundle->getBundleEntityManager());
-
-            if ($force) {
-                $output->writeln('<info>Running update</info>');
-
-                $bundle->update();
-            }
-
-            $output->writeln('<info>SQL executed: </info>'.PHP_EOL.implode(";".PHP_EOL, $sqls).'');
+        foreach ($this->getContainer()->get('bbapp')->getBundles() as $bundle) {
+            $this->doExecute($bundle, $force, $methodToCall, $output);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getCommandType()
+    {
+        return AbstractBundleCommand::UPDATE_COMMAND;
     }
 }

--- a/Console/Command/BundleUpdateCommand.php
+++ b/Console/Command/BundleUpdateCommand.php
@@ -24,21 +24,16 @@
 namespace BackBee\Console\Command;
 
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
-
-use BackBee\Console\AbstractCommand;
 
 /**
  * Update bundle command.
  *
  * @category    BackBee
- *
  * @copyright   Lp digital system
- * @author      k.golovin
+ * @author      Eric Chau <eric.chau@lp-digital.fr>
  */
-class BundleUpdateCommand extends AbstractCommand
+class BundleUpdateCommand extends AbstractBundleCommand
 {
     /**
      * {@inheritdoc}
@@ -62,31 +57,8 @@ EOF
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function getCommandType()
     {
-        $name = strtr($input->getArgument('name'), '/', '\\');
-
-        $force = $input->getOption('force');
-
-        $bbapp = $this->getContainer()->get('bbapp');
-
-        $bundle = $bbapp->getBundle($name);
-        /* @var $bundle \BackBee\Bundle\AbstractBundle */
-
-        if (null === $bundle) {
-            throw new \InvalidArgumentException(sprintf("Not a valid bundle: %s", $name));
-        }
-
-        $output->writeln('Updating bundle: '.$bundle->getId().'');
-
-        $sqls = $bundle->getUpdateQueries($bundle->getBundleEntityManager());
-
-        if ($force) {
-            $output->writeln('<info>Running update</info>');
-
-            $bundle->update();
-        }
-
-        $output->writeln('<info>SQL executed: </info>'.PHP_EOL.implode(";".PHP_EOL, $sqls).'');
+        return AbstractBundleCommand::UPDATE_COMMAND;
     }
 }

--- a/DependencyInjection/Listener/ContainerListener.php
+++ b/DependencyInjection/Listener/ContainerListener.php
@@ -40,11 +40,9 @@ use BackBee\Event\Event;
 class ContainerListener
 {
     /**
-     * [onApplicationInit description].
+     * Occurs on event ``bbapplication.init`` to dump application container if debug mode is false.
      *
-     * @param Event $event [description]
-     *
-     * @return [type] [description]
+     * @param Event $event
      */
     public static function onApplicationInit(Event $event)
     {
@@ -52,18 +50,19 @@ class ContainerListener
         $container = $application->getContainer();
 
         if (false === $application->isDebugMode() && false === $container->isRestored()) {
-            $container_filename = $container->getParameter('container.filename');
-            $container_directory = $container->getParameter('container.dump_directory');
+            $containerFilename = $container->getParameter('container.filename');
+            $containerDir = $container->getParameter('container.dump_directory');
 
-            if (false === is_dir($container_directory) && false === @mkdir($container_directory, 0755)) {
-                throw new CannotCreateContainerDirectoryException($container_directory);
+            if (false === is_dir($containerDir) && false === @mkdir($containerDir, 0755)) {
+                throw new CannotCreateContainerDirectoryException($containerDir);
             }
 
-            if (false === is_writable($container_directory)) {
-                throw new ContainerDirectoryNotWritableException($container_directory);
+            if (false === is_writable($containerDir)) {
+                throw new ContainerDirectoryNotWritableException($containerDir);
             }
 
             $dumper = new PhpArrayDumper($container);
+
             $dump = $dumper->dump(array('do_compile' => true));
 
             $container_proxy = new ContainerProxy();
@@ -73,9 +72,9 @@ class ContainerListener
             $container_proxy->setParameter('is_compiled', $dump['is_compiled']);
 
             file_put_contents(
-                $container_directory.DIRECTORY_SEPARATOR.$container_filename.'.php',
+                $containerDir.DIRECTORY_SEPARATOR.$containerFilename.'.php',
                 (new PhpDumper($container_proxy))->dump(array(
-                    'class'      => $container_filename,
+                    'class'      => $containerFilename,
                     'base_class' => 'BackBee\DependencyInjection\ContainerProxy',
                 ))
             );


### PR DESCRIPTION
This PR aims to get every bundle command works again. I also moved the ``install`` and ``update`` process from ``AbstractBundle`` to ``BundleLoader`` so every class that extend ``AbstractBundle`` will be lighter.

During the installation or update of a bundle we also dispatch 4 new events: (considering for the example below that the bundle _id_ is ``demo``)

- ``bundle.demo.preinstall`` is dispatched before ``BundleLoader`` install bundle Doctrine entities
- ``bundle.demo.postinstall`` is dispatched after ``BundleLoader`` install bundle Doctrine entities
- ``bundle.demo.preupdate`` is dispatched before ``BundleLoader`` update bundle Doctrine entities
- ``bundle.demo.postupdate`` is dispatched after ``BundleLoader`` update bundle Doctrine entities

There is also two new class events, ``Bundle/Event/BundleInstallEvent`` and ``Bundle/Event/BundleUpdateEvent``.

ping @crouillon, @mickaelandrieu.