### PR TITLE
Rest site controller

### DIFF
--- a/Config/route.yml
+++ b/Config/route.yml
@@ -387,6 +387,15 @@ bb.rest.layout.delete:
         version: \d+
         _method: DELETE
 
+bb.rest.site.get_collection:
+    pattern: /rest/{version}/site
+    defaults:
+        _action: getCollectionAction
+        _controller: BackBee\Rest\Controller\SiteController
+    requirements:
+        version: \d+
+        _method: GET
+
 bb.rest.classcontent.category.get:
     pattern: /rest/{version}/classcontent-category/{id}
     defaults:

--- a/Rest/Controller/SiteController.php
+++ b/Rest/Controller/SiteController.php
@@ -74,4 +74,26 @@ class SiteController extends AbstractRestController
 
         return new Response($this->formatCollection($layouts), 200, ['Content-Type' => 'application/json']);
     }
+
+    /**
+     * retrieve all Site visible for the current user
+     *
+     * @return Response
+     */
+    public function getCollectionAction()
+    {
+        if (!$this->isGranted('ROLE_API_USER')) {
+            throw new AccessDeniedHttpException('Your account\'s api access is disabled');
+        }
+        $sitesAvailable = [];
+        $sites = $this->getEntityManager()->getRepository('BackBee\Site\Site')->findAll();
+
+        foreach ($sites as $site) {
+            if ($this->isGranted('VIEW', $site)) {
+                $sitesAvailable[] = $site;
+            }
+        }
+        return new Response($this->formatCollection($sitesAvailable), 200,  ['Content-Type' => 'application/json']);
+    }
+
 }

--- a/Rest/Tests/Controller/SiteControllerTest.php
+++ b/Rest/Tests/Controller/SiteControllerTest.php
@@ -172,6 +172,31 @@ class SiteControllerTest extends TestCase
         $this->assertEquals(404, $response->getStatusCode());
     }
 
+        /**
+     * @covers ::getLayoutsAction
+     */
+    public function test_getSiteController()
+    {
+        $user = $this->createAuthUser('super_admin', array('ROLE_API_USER'));
+
+        $aclManager = $this->getBBApp()->getContainer()->get('security.acl_manager');
+        $aclManager->insertOrUpdateObjectAce(
+            new ObjectIdentity($this->site->getObjectIdentifier(), get_class($this->site)),
+            new UserSecurityIdentity($user->getGroups()[0]->getId(), 'BackBee\Security\Group'),
+            MaskBuilder::MASK_VIEW
+        );
+        // authenticate a user with super admin authority
+        $controller = $this->getController();
+        $response = $controller->getCollectionAction(new Request());
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $content = json_decode($response->getContent(), true);
+        $this->assertInternalType('array', $content);
+
+        $this->assertCount(1, $content);
+    }
+
     protected function tearDown()
     {
         $this->dropDb($this->getBBApp());


### PR DESCRIPTION
This is an method addition to rest site controller: getSiteCollection.

note: I'm not sure but I think getLayoutsAction method is unused and it can be removed because there is no route to bind this action.