### PR TITLE
[Controller] Fix controller event name

### DIFF
--- a/Controller/FrontController.php
+++ b/Controller/FrontController.php
@@ -619,6 +619,6 @@ class FrontController implements HttpKernelInterface
             $eventName = str_replace('frontcontroller.', '', $eventName);
         }
 
-        return $eventName.'.'.$actionName;
+        return $eventName.'.'.strtolower($actionName);
     }
 }


### PR DESCRIPTION
I have noticed than all events are written in lower case except postcall events.
That PR fixed this problem

Before PR : `rest.controller.classcontentcontroller.getAction.postcall`
After PR : `rest.controller.classcontentcontroller.getaction.postcall`