### PR TITLE
[Security] fixed session auto logout after n minutes

### DIFF
--- a/Security/Context/RestfulContext.php
+++ b/Security/Context/RestfulContext.php
@@ -58,7 +58,6 @@ class RestfulContext extends AbstractContext implements ContextInterface
             ], (array) $config['restful']);
 
             if (false !== ($defaultProvider = $this->getDefaultProvider($config))) {
-
                 $this->_context->getAuthenticationManager()
                     ->addProvider(
                         new PublicKeyAuthenticationProvider(
@@ -67,7 +66,8 @@ class RestfulContext extends AbstractContext implements ContextInterface
                             $config['lifetime'],
                             true === $config['use_registry'] ? $this->getRegistryRepository() : null,
                             $this->_context->getEncoderFactory(),
-                            $this->getApiUserRole()
+                            $this->getApiUserRole(),
+                            $this->_context->getApplication()->getSession()
                         )
                     )
                     ->addProvider(


### PR DESCRIPTION
This PR brings fix for https://github.com/backbee/backbee-standard/issues/257.

The issue is that the token used by front_area security is setted only once at the first authentication of the user. Rest of the time we keep updating the expire time of the rest_area but not the front_area token.

Ping @crouillon, @mickaelandrieu. I tried to fix it with a better way but our Security component is kinda out of date compare to SF 2.7 recommandations.