### PR TITLE
[NestedNode] Fix generation of url with special characters like '+'

### DIFF
--- a/NestedNode/Tests/PageUrlRewritingTest.php
+++ b/NestedNode/Tests/PageUrlRewritingTest.php
@@ -90,6 +90,12 @@ class PageUrlRewritingTest extends BackBeeTestCase
         $this->assertEquals('/backbee-2', $this->generatePage('backbee', null, true)->getUrl());
     }
 
+    public function testGenerateUniqueUrlWithSpecialCharacters()
+    {
+        $this->assertEquals('/backbee+', $this->generatePage('backbee+', null, true)->getUrl());
+        $this->assertEquals('/backbee+-1', $this->generatePage('backbee+', null, true)->getUrl());
+    }
+
     public function testReplaceOldDeletedUrl()
     {
         $this->assertTrue($this->urlGenerator->isPreserveUnicity());

--- a/Rewriting/UrlGenerator.php
+++ b/Rewriting/UrlGenerator.php
@@ -285,7 +285,7 @@ class UrlGenerator implements UrlGeneratorInterface
             $existings = $this->application->getEntityManager()->getConnection()->executeQuery(
                 'SELECT p.uid FROM page p LEFT JOIN section s ON s.uid = p.section_uid WHERE s.root_uid = :root AND p.url REGEXP :regex',
                 [
-                    'regex' => $url.'(-[0-9]+)?$',
+                    'regex' => str_replace(['+'], ['[+]'], $url).'(-[0-9]+)?$',
                     'root'  => $page->getRoot()->getUid(),
                 ]
             )->fetchAll();


### PR DESCRIPTION
Currently, if the url contain "+", the url generator create a duplicate url