### PR TITLE
Add form component as suggested dependency

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -133,6 +133,10 @@ class Controller implements ContainerAwareInterface
      */
     public function createFormBuilder($data)
     {
+        if (!class_exists('Symfony\\Component\\Form\\Forms')) {
+            throw new \RuntimeException('Unable to use ``createFormBuilder`` function as the Symfony Form Component is not installed.');
+        }
+
         $validator = Validation::createValidator();
 
         $formFactory = Forms::createFormFactoryBuilder()

--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,9 @@
         "backbee/bb-core-js": "1.0.0",
         "symfony/phpunit-bridge": "~2.7.0"
     },
+    "suggest": {
+        "symfony/form": "Allows you to use Symfony Form Component integration"
+    },
     "minimum-stability": "stable",
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
If the component is not installed, we are unable to use ``Controller::createFromBuilder()``.

This contribution introduce an exception with an explicit message to solve the issue, and suggest the installation of Symfony Form component on Composer installation.

ping @eric-chau 