### PR TITLE
[Entity] optimize length field for md5 uids

### DIFF
--- a/ClassContent/AbstractContent.php
+++ b/ClassContent/AbstractContent.php
@@ -62,7 +62,7 @@ abstract class AbstractContent implements ObjectIdentifiableInterface, Renderabl
      *
      * @var string
      * @ORM\Id
-     * @ORM\Column(type="string", name="uid")
+     * @ORM\Column(type="string", lenght=32, name="uid")
      */
     protected $_uid;
 

--- a/ClassContent/AbstractContent.php
+++ b/ClassContent/AbstractContent.php
@@ -62,7 +62,7 @@ abstract class AbstractContent implements ObjectIdentifiableInterface, Renderabl
      *
      * @var string
      * @ORM\Id
-     * @ORM\Column(type="string", lenght=32, name="uid")
+     * @ORM\Column(type="string", length=32, name="uid")
      */
     protected $_uid;
 

--- a/Logging/AdminLog.php
+++ b/Logging/AdminLog.php
@@ -42,7 +42,7 @@ class AdminLog
     /**
      * @var string
      * @ORM\Id
-     * @ORM\Column(type="string", name="uid")
+     * @ORM\Column(type="string", length=32, name="uid")
      */
     protected $_uid;
 

--- a/NestedNode/AbstractNestedNode.php
+++ b/NestedNode/AbstractNestedNode.php
@@ -55,7 +55,7 @@ abstract class AbstractNestedNode extends AbstractObjectIdentifiable
      *
      * @var string
      * @ORM\Id
-     * @ORM\Column(type="string", name="uid")
+     * @ORM\Column(type="string", length=32, name="uid")
      *
      * @Serializer\Type("string")
      */

--- a/NestedNode/KeyWord.php
+++ b/NestedNode/KeyWord.php
@@ -55,7 +55,7 @@ class KeyWord extends AbstractNestedNode implements RenderableInterface, \JsonSe
      *
      * @var string
      * @ORM\Id
-     * @ORM\Column(type="string", name="uid")
+     * @ORM\Column(type="string", length=32, name="uid")
      *
      * @Serializer\Expose
      * @Serializer\SerializedName("id")

--- a/NestedNode/MediaFolder.php
+++ b/NestedNode/MediaFolder.php
@@ -49,7 +49,7 @@ class MediaFolder extends AbstractNestedNode implements \JsonSerializable
      *
      * @var string
      * @ORM\Id
-     * @ORM\Column(type="string", name="uid")
+     * @ORM\Column(type="string", length=32, name="uid")
      */
     protected $_uid;
 

--- a/NestedNode/Tests/Mock/MockNestedNode.php
+++ b/NestedNode/Tests/Mock/MockNestedNode.php
@@ -47,7 +47,7 @@ class MockNestedNode extends AbstractNestedNode implements MockInterface
      *
      * @var string
      * @ORM\Id
-     * @ORM\Column(type="string", name="uid")
+     * @ORM\Column(type="string", length=32, name="uid")
      *
      * @Serializer\Type("string")
      */

--- a/Site/Layout.php
+++ b/Site/Layout.php
@@ -70,7 +70,7 @@ class Layout extends AbstractObjectIdentifiable
      *
      * @var string
      * @ORM\Id
-     * @ORM\Column(type="string", name="uid")
+     * @ORM\Column(type="string", length=32, name="uid")
      *
      * @Serializer\Expose
      * @Serializer\Type("string")

--- a/Site/Site.php
+++ b/Site/Site.php
@@ -58,7 +58,7 @@ class Site extends AbstractObjectIdentifiable
      *
      * @var string
      * @ORM\Id
-     * @ORM\Column(type="string", name="uid")
+     * @ORM\Column(type="string", length=32, name="uid")
      * @BB\Fixture(type="md5")
      *
      * @Serializer\Expose

--- a/Util/BBAbstract/AbstractUidEntity.php
+++ b/Util/BBAbstract/AbstractUidEntity.php
@@ -37,7 +37,7 @@ abstract class AbstractUidEntity implements DomainObjectInterface
     /**
      * @var string
      * @ORM\Id
-     * @ORM\Column(type="string", name="uid")
+     * @ORM\Column(type="string", length=32, name="uid")
      */
     protected $_uid;
 

--- a/Workflow/State.php
+++ b/Workflow/State.php
@@ -54,7 +54,7 @@ class State extends AbstractObjectIdentifiable implements \JsonSerializable
      *
      * @var string
      * @ORM\Id
-     * @ORM\Column(type="string", name="uid")
+     * @ORM\Column(type="string", length=32, name="uid")
      *
      * @Serializer\Expose
      * @Serializer\Type("string")


### PR DESCRIPTION
I rewrite annotation to optimize length field for all uids which are in md5. 
I hope that will optimize memory allocation  for database requests. 

impacted class : 
- ClassContent/AbstractContent.php
- Logging/AdminLog.php
- NestedNode/AbstractNestedNode.php
- NestedNode/KeyWord.php
- NestedNode/MediaFolder.php
- NestedNode/Tests/Mock/MockNestedNode.php 
- Site/Layout.php
- Site/Site.php
- Util/BBAbstract/AbstractUidEntity.php
- Workflow/State.php

I add "length=32," on those fields.

