### PR TITLE
[Config] fix case for getaction.postcall in events.yml

### DIFF
--- a/ClassContent/Tests/Listener/ClassContentListenerTest.php
+++ b/ClassContent/Tests/Listener/ClassContentListenerTest.php
@@ -44,7 +44,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class ClassContentListenerTest extends BackBeeTestCase
 {
-    const POST_CALL_EVENT_NAME = 'rest.controller.classcontentcontroller.getAction.postcall';
+    const POST_CALL_EVENT_NAME = 'rest.controller.classcontentcontroller.getaction.postcall';
 
     /**
      * @var BackBee\ClassContent\ClassContentManager

--- a/Config/events.yml
+++ b/Config/events.yml
@@ -32,7 +32,7 @@ classcontent.postrender:
     listeners:
         - [@cache.listener, onPostRenderContent]
 
-rest.controller.classcontentcontroller.getAction.postcall:
+rest.controller.classcontentcontroller.getaction.postcall:
   listeners:
     - [BackBee\ClassContent\Listener\ClassContentListener, onPostCall]
 


### PR DESCRIPTION
I change getAction to getaction because all events are in lower case in events.yml and in ClassContent/Test/Listener