### PR TITLE
[ClassContent] updated ClassContentManager::prepareElements()

### DIFF
--- a/ClassContent/ClassContentManager.php
+++ b/ClassContent/ClassContentManager.php
@@ -383,7 +383,7 @@ class ClassContentManager
     private function updateContentElements(AbstractClassContent $content, array $elementsData)
     {
         foreach ($elementsData as $key => $data) {
-            $content->$key = $data;
+            $content->$key = (array) $data;
         }
 
         return $this;
@@ -410,16 +410,24 @@ class ClassContentManager
                 continue;
             }
 
-            if (
-                    isset($data['type'])
-                    && isset($data['uid'])
-                    && null !== $element = $this->findOneByTypeAndUid($data['type'], $data['uid'])
-            ) {
-                $elements[$key] = $element;
+            if (isset($data['type']) && isset($data['uid'])) {
+                if (null !== $element = $this->findOneByTypeAndUid($data['type'], $data['uid'])) {
+                    $elements[$key] = $element;
+                }
+
                 continue;
             }
 
-            $elements[$key] = $this->prepareElements($data, false);
+            $elements[$key] = [];
+            foreach ($data as $row) {
+                if (
+                    isset($row['type'])
+                    && isset($row['uid'])
+                    && null !== $element = $this->findOneByTypeAndUid($row['type'], $row['uid'])
+                ) {
+                    $elements[$key][] = $element;
+                }
+            }
         }
 
         return $elements;

--- a/Rest/Controller/ClassContentController.php
+++ b/Rest/Controller/ClassContentController.php
@@ -226,8 +226,6 @@ class ClassContentController extends AbstractRestController
      */
     public function putAction($type, $uid, Request $request)
     {
-        $this->granted('VIEW', $this->getClassContentManager()->findOneByTypeAndUid($type, $uid, true));
-        $this->granted('EDIT', $this->getClassContentManager()->findOneByTypeAndUid($type, $uid, true));
         $this->updateClassContent($type, $uid, $request->request->all());
         $this->getEntityManager()->flush();
 


### PR DESCRIPTION
Updated `ClassContentManager::prepareElements()`  to handle array of values of an element. Example, if you want to add two keywords to an article:

```js
// PUT /rest/1/classcontent/Article/Aticle/d775e20c62b018d84c1a12229ef9477d
{
    "elements": {
        "keywords": [
            {
                "uid": "04b89c815c65bcde9be3b5fb28f72f64",
                "type": "Element/Keyword"
            },
            {
                "uid": "dee512eb518042412ea374f2e8c272e8",
                "type": "Element/Keyword"
            }
        ]
    },
    "type": "Article/Article",
    "uid": "d775e20c62b018d84c1a12229ef9477d"
}
```

ping @crouillon, @fkroockmann.