### PR TITLE
introduced getResourcesDirectory() in AbstractBundle

### DIFF
--- a/Bundle/AbstractBundle.php
+++ b/Bundle/AbstractBundle.php
@@ -119,6 +119,14 @@ abstract class AbstractBundle implements BundleInterface
     }
 
     /**
+     * @return the path to the Resources folder
+     */
+    public function getResourcesDirectory()
+    {
+        return $this->baseDir.DIRECTORY_SEPARATOR.'Resources';
+    }
+
+    /**
      * @see BackBee\Bundle\BundleInterface::getProperty
      */
     public function getProperty($key = null)


### PR DESCRIPTION
As discussed with some of the core team, we need this accessor to get translation files from Bundles.

Sorry for tests, there is no one I will try to cover the Bundle part in another pull request.