### PR TITLE
Fix bug objectKeyword does not a parameter

### DIFF
--- a/ClassContent/Element/Keyword.yml
+++ b/ClassContent/Element/Keyword.yml
@@ -7,3 +7,5 @@ Keyword:
     value: !!scalar
   fixture:
     value: word
+  parameters:
+    objectkeyword: []

--- a/NestedNode/Repository/KeyWordRepository.php
+++ b/NestedNode/Repository/KeyWordRepository.php
@@ -185,7 +185,7 @@ class KeyWordRepository extends NestedNodeRepository
 
         foreach ($objects as $object) {
             if (true === array_key_exists($object->getUid(), $assoc)) {
-                $assoc[$object->getUid()]->setParam('objectKeyword', $object, 'object');
+                $assoc[$object->getUid()]->setParam('objectkeyword', [$object]);
             }
         }
 


### PR DESCRIPTION
I have noticed than all parameters must be set in ClassContent (in lower case).
That PR fixed this problem for ClassContent/Element/Keyword

- Add parameters/objectkeyword in ClassContent/Element/Keyword as array
- Change name from 'objectKeyword' to 'objectkeyword' in NestedNode/Repository/KeyWordRepository