### PR TITLE
Make the session configuration optional

### DIFF
--- a/Session/SessionConfigurator.php
+++ b/Session/SessionConfigurator.php
@@ -42,7 +42,7 @@ class SessionConfigurator
 
     public function __construct(Config $config, SessionStorageInterface $sessionStorage, SessionHandlerInterface $sessionHandler = null)
     {
-        $this->sessionConfig = $config->getSessionConfig();
+        $this->sessionConfig = is_array($config->getSessionConfig()) ? $config->getSessionConfig() : [];
         $this->sessionStorage = $sessionStorage;
         $this->sessionHandler = $sessionHandler;
     }


### PR DESCRIPTION
Please note that the `bb_session` service is configured by `session` key /c @fkroockmann @eric-chau @crouillon 