### PR TITLE
[SwiftMailer] fix encryption if not set in mailer.yml config file

### DIFF
--- a/BBApplication.php
+++ b/BBApplication.php
@@ -195,7 +195,7 @@ class BBApplication implements ApplicationInterface, DumpableServiceInterface, D
                 $smtp = is_array($mailer_config['smtp']) ? reset($mailer_config['smtp']) : $mailer_config['smtp'];
                 $port = is_array($mailer_config['port']) ? reset($mailer_config['port']) : $mailer_config['port'];
                 $encryption = !isset($mailer_config['encryption'])
-                    ?: (is_array($mailer_config['encryption'])
+                    ? null : (is_array($mailer_config['encryption'])
                         ? reset($mailer_config['encryption'])
                         : $mailer_config['encryption']);
 


### PR DESCRIPTION
Return `null` instead of `false` in case no encryption is detected in mailer.yml