### PR TITLE
improved init of bundles in BBApplication when debug is setted to false

### DIFF
--- a/BBApplication.php
+++ b/BBApplication.php
@@ -41,8 +41,6 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -1203,8 +1201,9 @@ class BBApplication implements ApplicationInterface, DumpableServiceInterface, D
      */
     private function initBundles()
     {
-        if (null !== $this->getConfig()->getBundlesConfig()) {
-            $this->getContainer()->get('bundle.loader')->load($this->getConfig()->getBundlesConfig());
+        $bundleLoader = $this->getContainer()->get('bundle.loader');
+        if (!$bundleLoader->isRestored() && null !== $this->getConfig()->getBundlesConfig()) {
+            $bundleLoader->load($this->getConfig()->getBundlesConfig());
         }
 
         return $this;

--- a/Bundle/Listener/BundleListener.php
+++ b/Bundle/Listener/BundleListener.php
@@ -42,10 +42,10 @@ class BundleListener
      */
     public static function onApplicationStop(Event $event)
     {
-        $application = $event->getTarget();
-        foreach (array_keys($application->getContainer()->findTaggedServiceIds('bundle')) as $bundle_id) {
-            if (true === $application->getContainer()->hasInstanceOf($bundle_id)) {
-                $application->getContainer()->get($bundle_id)->stop();
+        $container = $event->getTarget()->getContainer();
+        foreach (array_keys($container->findTaggedServiceIds('bundle')) as $bundleId) {
+            if ($container->hasInstanceOf($bundleId)) {
+                $container->get($bundleId)->stop();
             }
         }
     }


### PR DESCRIPTION
We load every bundle's config only if the bundle loader is not restored. Tests on my side shows up an improvement of ~10 ms.