### PR TITLE
[Renderer] added TwigListener::onApplicationReady() to load twig extensions

### DIFF
--- a/Config/events.yml
+++ b/Config/events.yml
@@ -126,6 +126,7 @@ bbapplication.init:
     listeners:
         - [BackBee\DependencyInjection\Listener\ContainerListener, onApplicationInit]
         - [BackBee\ClassContent\Listener\ClassContentListener, onApplicationInit]
+        - [BackBee\Renderer\Listener\TwigListener, onApplicationReady]
 
 bbapplication.stop:
     listeners:

--- a/Renderer/Adapter/Twig.php
+++ b/Renderer/Adapter/Twig.php
@@ -88,11 +88,6 @@ class Twig extends AbstractRendererAdapter
             ;
             $this->setTwigCache($cacheDir);
         }
-
-        // loads every Twig extension registered in application's service container
-        foreach ($app->getContainer()->findTaggedServiceIds('twig.extension') as $id => $datas) {
-            $this->addExtension($app->getContainer()->get($id));
-        }
     }
 
     /**

--- a/Renderer/Listener/TwigListener.php
+++ b/Renderer/Listener/TwigListener.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Renderer\Listener;
+
+use BackBee\Event\Event;
+
+/**
+ * Twig renderer adapter listener.
+ *
+ * @category    BackBee
+ *
+ * @copyright   Lp digital system
+ * @author      Eric Chau <eric.chau@lp-digital.fr>
+ */
+class TwigListener
+{
+    /**
+     * occurs on `bbapplication.init`.
+     *
+     * @param Event $event
+     */
+    public static function onApplicationReady(Event $event)
+    {
+        $app = $event->getTarget();
+
+        $twigAdapter = $app->getRenderer()->getAdapter('twig');
+        if (null === $twigAdapter) {
+            return;
+        }
+
+        foreach ($app->getContainer()->findTaggedServiceIds('twig.extension') as $id => $data) {
+            $twigAdapter->addExtension($app->getContainer()->get($id));
+        }
+    }
+}


### PR DESCRIPTION
PR #645 initiated by myself removed the `TwigListener` and the loading of Twig's extensions is done in `Adapter\Twig::__construct()`. It can introduce bug in some cases like if the `Renderer` is invoked very early. So this specific behavior must be reverted.
Also I moved the listener to listen `bbapplication.init` instead of `bbapplication.start` so even is CLI mode Renderer will be configured as expected.
