### PR TITLE
#531 redefine and develop search on pages

### DIFF
--- a/Rest/Controller/PageController.php
+++ b/Rest/Controller/PageController.php
@@ -765,9 +765,12 @@ class PageController extends AbstractRestController
 
         if (null !== $parent) {
             $this->granted('VIEW', $parent);
-
-            // Ordering is disabled for descendants, BackBee takes care of that
-            $qb->andIsDescendantOf($parent, true, $request->query->get('level_offset', 1), $this->getOrderCriteria(), $count, $start);
+            if ($request->query->get('search_action') == 1) {
+                $qb->andIsDescendantOf($parent, true, null, $this->getOrderCriteria($request->query->get('order_by', null)), $count, $start);
+            } else {
+                // Ordering is disabled for descendants, BackBee takes care of that
+                $qb->andIsDescendantOf($parent, true, $request->query->get('level_offset', 1), $this->getOrderCriteria(), $count, $start);
+            }
         } else {
             if ($request->query->has('site_uid')) {
                 $site = $this->getSiteRepository()->find($request->query->get('site_uid'));


### PR DESCRIPTION
[PAGE MANAGEMENT] redefine and develop search on pages 
- new parameter added to make the difference between page list and page tree
- translation for label "No page found." are needed for this languages: chines, russian, german