### PR TITLE
Sequencer : avoid Doctrine cache and force reading from database

### DIFF
--- a/Util/Sequence/Sequencer.php
+++ b/Util/Sequence/Sequencer.php
@@ -174,6 +174,7 @@ class Sequencer extends EntityRepository
             return $this->init($name, $default);
         }
 
+        $this->_em->refresh($seq);
         return $seq->getValue();
     }
 


### PR DESCRIPTION
We need to get a refreshed new value from database in a foreach loop for exemple.
The Doctrine cache avoids that till the Entity is not refreshed.
