### PR TITLE
[DROPZONE] #547 - enable user to drop blocks only in zones that can handle the right render mode

### DIFF
--- a/ClassContent/AbstractContent.php
+++ b/ClassContent/AbstractContent.php
@@ -709,10 +709,16 @@ abstract class AbstractContent implements ObjectIdentifiableInterface, Renderabl
     {
         if ($this->getContentInstance() instanceof ContentSet) {
             if (!($value instanceof AbstractClassContent)) {
+                // ContentSet accepts only AbstractClassContent elements
+                return false;
+            }
+            
+            if (in_array('!' . $this->_getType($value), $this->_accept)) {
+                // ContentSet can exclude content types
                 return false;
             }
 
-            $acceptArray = $this->_accept;
+            $acceptArray = array_filter($this->_accept, function($item) { return '!' !== substr($item, 0, 1); });
         } else {
             if (null === $var) {
                 return false;
@@ -1180,7 +1186,7 @@ abstract class AbstractContent implements ObjectIdentifiableInterface, Renderabl
             $this->properties[$var] = $value;
         }
 
-        return $this;
+        return $this->setOptions($this->properties);
     }
 
     /**

--- a/Stream/ClassWrapper/Adapter/Yaml.php
+++ b/Stream/ClassWrapper/Adapter/Yaml.php
@@ -116,8 +116,16 @@ class Yaml extends AbstractClassWrapper
                         $options['label'] = $value['label'];
                     }
 
+                    if (isset($value['accept'])) {
+                        $options['accept'] = $value['accept'];
+                    }
+
                     if (isset($value['maxentry'])) {
                         $options['maxentry'] = $value['maxentry'];
+                    }
+
+                    if (isset($value['minentry'])) {
+                        $options['minentry'] = $value['minentry'];
                     }
 
                     if (isset($value['parameters'])) {


### PR DESCRIPTION
 * Introduce the exclusion of content type in accept arrays by prefixing classname with !
 * Allow to define accept array in subcontent defintions, for example:
```
ColumnDivider:
    properties:
        name : Column divider
        description: "Column divider"
        category: [Block]
    elements:
        first_container:
            type: BackBee\ClassContent\ContentSet
            accept: [BackBee\ClassContent\Home\HomeArticleContainer]
            maxentry: 1
```