### PR TITLE
Tree adjustments refs:#5362

### DIFF
--- a/Rest/Controller/PageController.php
+++ b/Rest/Controller/PageController.php
@@ -769,7 +769,7 @@ class PageController extends AbstractRestController
                 $qb->andIsDescendantOf($parent, true, null, $this->getOrderCriteria($request->query->get('order_by', null)), $count, $start);
             } else {
                 // Ordering is disabled for descendants, BackBee takes care of that
-                $qb->andIsDescendantOf($parent, true, $request->query->get('level_offset', 1), $this->getOrderCriteria(), $count, $start);
+                $qb->andIsDescendantOf($parent, true, $request->query->get('level_offset', 1), $this->getOrderCriteria(null, $qb), $count, $start);
             }
         } else {
             if ($request->query->has('site_uid')) {
@@ -842,7 +842,7 @@ class PageController extends AbstractRestController
      *
      * @return array
      */
-    private function getOrderCriteria(array $requestedOrder = null)
+    private function getOrderCriteria(array $requestedOrder = null, $qb = null)
     {
         if (!empty($requestedOrder)) {
             $orderBy = [];
@@ -854,10 +854,11 @@ class PageController extends AbstractRestController
                 $orderBy[$key] = $value;
             }
         } else {
-            $orderBy = [
-                '_position' => 'ASC',
-                '_leftnode' => 'ASC',
-            ];
+            $orderBy['_position'] = 'ASC';
+            if ($qb) {
+                $orderBy[ $qb->getSectionAlias().'._has_children'] = 'DESC';
+            }
+            $orderBy['_leftnode'] = 'ASC';
         }
 
         return $orderBy;


### PR DESCRIPTION
Changes for the following requests:
2. Pages that have subpages must be displayed before single pages
3. When creating a new page, display the page right after it parent . when reloading tree, page must go down after pages that have children
4. As soon as the toobar is loaded , load the tree in background task (for user to have it display quick when he'll click on it)(edited)