### PR TITLE
[ENHANCEMENT] Allow to define the overriding configuration persist level

### DIFF
--- a/Config/Persistor.php
+++ b/Config/Persistor.php
@@ -66,8 +66,10 @@ class Persistor
     /**
      * Persistor's constructor.
      *
-     * @param ApplicationInterface $application  the application this persistor belongs to
-     * @param Configurator         $configurator provider of config default settings
+     * @param ApplicationInterface $application           The application this persistor belongs to.
+     * @param Configurator         $configurator          Provider of config default settings.
+     * @param boolean              $persistPerContext     Is a config is persisted by application context ?
+     * @param boolean              $persistPerEnvironment Is a config is persisted by application environment ?
      */
     public function __construct(ApplicationInterface $application, Configurator $configurator)
     {
@@ -134,13 +136,16 @@ class Persistor
         if (null !== $config = $this->application->getConfig()) {
             $config_config = $config->getConfigConfig();
 
-            if (false === is_array($config_config) || false === array_key_exists('persistor', $config_config)) {
+            if (!is_array($config_config) || !array_key_exists('persistor', $config_config)) {
                 throw new PersistorListNotFoundException();
             }
 
+            $persistPerContext = !isset($config_config['persist_per_context']) || true === $config_config['persist_per_context'];
+            $persistPerEnvironment = !isset($config_config['persist_per_environment']) || true === $config_config['persist_per_environment'];
+
             $persistors = (array) $config_config['persistor'];
             foreach ($persistors as $persistor_classname) {
-                $persistor = new $persistor_classname($this->application);
+                $persistor = new $persistor_classname($this->application, $persistPerContext, $persistPerEnvironment);
                 if (false === ($persistor instanceof PersistorInterface)) {
                     throw new InvalidArgumentException(
                         get_class($persistor).' must implements BackBee\Config\Persistor\PersistorInterface'

--- a/Config/Persistor/File.php
+++ b/Config/Persistor/File.php
@@ -41,11 +41,27 @@ class File implements PersistorInterface
     private $app;
 
     /**
+     * Is a configuration is persisted by application context ?
+     *
+     * @var boolean
+     */
+    private $persistPerContext;
+
+    /**
+     * Is a configuration is persisted by application environment ?
+     *
+     * @var boolean
+     */
+    private $persistPerEnvironment;
+
+    /**
      * @see BackBee\Config\Persistor\PersistorInterface::__construct
      */
-    public function __construct(ApplicationInterface $app)
+    public function __construct(ApplicationInterface $app, $persistPerContext, $persistPerEnvironment)
     {
         $this->app = $app;
+        $this->persistPerContext = (true === $persistPerContext);
+        $this->persistPerEnvironment = (true === $persistPerEnvironment);
     }
 
     /**
@@ -74,13 +90,13 @@ class File implements PersistorInterface
      */
     private function getConfigDumpRightDirectory($baseDir)
     {
-        $configDumpDir = $this->app->getRepository();
-        if (ApplicationInterface::DEFAULT_CONTEXT !== $this->app->getContext()) {
+        $configDumpDir = $this->app->getBaseRepository();
+        if ($this->persistPerContext && ApplicationInterface::DEFAULT_CONTEXT !== $this->app->getContext()) {
             $configDumpDir .= DIRECTORY_SEPARATOR.$this->app->getContext();
         }
 
         $configDumpDir .= DIRECTORY_SEPARATOR.'Config';
-        if (ApplicationInterface::DEFAULT_ENVIRONMENT !== $this->app->getEnvironment()) {
+        if ($this->persistPerEnvironment && ApplicationInterface::DEFAULT_ENVIRONMENT !== $this->app->getEnvironment()) {
             $configDumpDir .= DIRECTORY_SEPARATOR.$this->app->getEnvironment();
         }
 

--- a/Config/Persistor/PersistorInterface.php
+++ b/Config/Persistor/PersistorInterface.php
@@ -36,9 +36,11 @@ interface PersistorInterface
 {
     /**
      *
-     * @param ApplicationInterface $application The BackBee application instance
+     * @param ApplicationInterface $application           The BackBee application instance
+     * @param boolean              $persistPerContext     Is one config is persisted per application context ?
+     * @param boolean              $persistPerEnvironment Is one config is persisted per application environment ?
      */
-    public function __construct(ApplicationInterface $application);
+    public function __construct(ApplicationInterface $application, $persistPerContext, $persistPerEnvironment);
 
     /**
      *

--- a/Config/Tests/ConfiguratorTest.php
+++ b/Config/Tests/ConfiguratorTest.php
@@ -141,4 +141,56 @@ class ConfiguratorTest extends \PHPUnit_Framework_TestCase
             $config->getAllSections()
         );
     }
+
+    /**
+     * @covers ::getRegistryScope
+     */
+    public function testGetDefaultRegistryScope()
+    {
+        $configurator = new Configurator($this->application, $this->bundleLoader);
+        $this->assertEquals('PREFIX', $configurator->getRegistryScope('PREFIX', true, true));
+        $this->assertEquals('PREFIX', $configurator->getRegistryScope('PREFIX', false, true));
+        $this->assertEquals('PREFIX', $configurator->getRegistryScope('PREFIX', true, false));
+        $this->assertEquals('PREFIX', $configurator->getRegistryScope('PREFIX', false, false));
+    }
+
+    /**
+     * @covers ::getRegistryScope
+     */
+    public function testGetRegistryScopeWithContext()
+    {
+        $this->application->setContext('api');
+        $configurator = new Configurator($this->application, $this->bundleLoader);
+        $this->assertEquals('PREFIX.api', $configurator->getRegistryScope('PREFIX', true, true));
+        $this->assertEquals('PREFIX', $configurator->getRegistryScope('PREFIX', false, true));
+        $this->assertEquals('PREFIX.api', $configurator->getRegistryScope('PREFIX', true, false));
+        $this->assertEquals('PREFIX', $configurator->getRegistryScope('PREFIX', false, false));
+    }
+
+    /**
+     * @covers ::getRegistryScope
+     */
+    public function testGetRegistryScopeWithEnvironment()
+    {
+        $this->application->setEnvironment('preprod');
+        $configurator = new Configurator($this->application, $this->bundleLoader);
+        $this->assertEquals('PREFIX.preprod', $configurator->getRegistryScope('PREFIX', true, true));
+        $this->assertEquals('PREFIX.preprod', $configurator->getRegistryScope('PREFIX', false, true));
+        $this->assertEquals('PREFIX', $configurator->getRegistryScope('PREFIX', true, false));
+        $this->assertEquals('PREFIX', $configurator->getRegistryScope('PREFIX', false, false));
+    }
+
+    /**
+     * @covers ::getRegistryScope
+     */
+    public function testGetRegistryScopeWithContextAndEnvironment()
+    {
+        $this->application->setContext('api');
+        $this->application->setEnvironment('preprod');
+        $configurator = new Configurator($this->application, $this->bundleLoader);
+        $this->assertEquals('PREFIX.api.preprod', $configurator->getRegistryScope('PREFIX', true, true));
+        $this->assertEquals('PREFIX.preprod', $configurator->getRegistryScope('PREFIX', false, true));
+        $this->assertEquals('PREFIX.api', $configurator->getRegistryScope('PREFIX', true, false));
+        $this->assertEquals('PREFIX', $configurator->getRegistryScope('PREFIX', false, false));
+    }
 }

--- a/Config/Tests/Persistor/FakePersistor.php
+++ b/Config/Tests/Persistor/FakePersistor.php
@@ -47,7 +47,7 @@ class FakePersistor implements PersistorInterface
     /**
      * {@inheritdoc}
      */
-    public function __construct(ApplicationInterface $application)
+    public function __construct(ApplicationInterface $application, $persistPerContext, $persistPerEnvironment)
     {
         $this->container = $application->getContainer();
     }


### PR DESCRIPTION
Introduce two optional configuration parameters to Config:config section:
 * _persist_per_context_: persist overriding config taking account of the context (true by default)
 * _persist_per_environment_: persist overriding config taking account of the environment (true by default)