### PR TITLE
Fix json encode on scalar element

### DIFF
--- a/ClassContent/AbstractClassContent.php
+++ b/ClassContent/AbstractClassContent.php
@@ -408,8 +408,8 @@ abstract class AbstractClassContent extends AbstractContent
                     }
 
                     if ('scalar' === $type) {
-                        $decode = json_decode($value);
-                        $clone->$key = (JSON_ERROR_NONE === json_last_error()) ? $decode : $value;
+                        $decode = json_decode($value, true);
+                        $clone->$key = (JSON_ERROR_NONE === json_last_error()) ? ((null === $decode) ? $value : $decode) : $value;
                     } elseif ('array' !== $type) {
                         foreach ($this->_subcontent as $subcontent) {
                             if ($subcontent->getUid() == $value) {

--- a/ClassContent/AbstractContent.php
+++ b/ClassContent/AbstractContent.php
@@ -712,7 +712,7 @@ abstract class AbstractContent implements ObjectIdentifiableInterface, Renderabl
                 // ContentSet accepts only AbstractClassContent elements
                 return false;
             }
-            
+
             if (in_array('!' . $this->_getType($value), $this->_accept)) {
                 // ContentSet can exclude content types
                 return false;
@@ -939,8 +939,8 @@ abstract class AbstractContent implements ObjectIdentifiableInterface, Renderabl
             }
 
             if ('scalar' === $type) {
-                $decode = json_decode($value);
-                $data[] = (JSON_ERROR_NONE === json_last_error()) ? $decode : $value;
+                $decode = json_decode($value, true);
+                $data[] = (JSON_ERROR_NONE === json_last_error()) ? ((null === $decode) ? $value : $decode) : $value;
             } elseif ('array' !== $type) {
                 try {
                     $type = self::getFullClassname($type);


### PR DESCRIPTION
Currently when scalar is empty or string the json decode return null instead of return the current string.

I add test to check if the json_decode dont have error and if the json decode return null.

I propose to set null if json decode throw error cause if we keep the current value, serialize will be broken

Let me know @eric-chau @crouillon 