### PR TITLE
[Renderer] fixed metadata helper cause it throws warning on some use case

### DIFF
--- a/Renderer/Helper/metadata.php
+++ b/Renderer/Helper/metadata.php
@@ -75,7 +75,7 @@ class metadata extends AbstractHelper
         }
 
         $result = '';
-        foreach ($metadata as $meta) {
+        foreach ($page->getMetadata() as $meta) {
             $result .= $this->generateMeta($meta);
         }
 


### PR DESCRIPTION
Currently, `Renderer/Helper/metadata::__invoke` throws warning when `$metadata` is `null`.