### PR TITLE
[ClassContent] fixed revision deletion on revert action

### DIFF
--- a/ClassContent/ClassContentManager.php
+++ b/ClassContent/ClassContentManager.php
@@ -545,8 +545,8 @@ class ClassContentManager
                         ;
                     }
                 }
-                unset($subcontent);
 
+                unset($subcontent);
                 if (in_array('Element\Keyword', $content->getAccept()[$key])) {
                     $this->entityManager
                         ->getRepository('BackBee\ClassContent\Element\Keyword')
@@ -660,11 +660,15 @@ class ClassContentManager
                 )
             )
         ) {
-            $this->entityManager->remove($draft);
+            if ($content instanceof ContentSet) {
+                $draft->clear();
+            }
 
             if (AbstractClassContent::STATE_NEW === $content->getState()) {
                 $classname = AbstractClassContent::getClassnameByContentType($content->getContentType());
                 $this->entityManager->getRepository($classname)->deleteContent($content);
+            } else {
+                $this->entityManager->remove($draft);
             }
         }
 

--- a/ClassContent/Repository/ClassContentRepository.php
+++ b/ClassContent/Repository/ClassContentRepository.php
@@ -959,12 +959,10 @@ class ClassContentRepository extends EntityRepository
             ]
         );
 
-        $this->_em->getConnection()->executeUpdate(
-            'DELETE FROM revision WHERE content_uid = :uid',
-            [
-                'uid' => $content->getUid(),
-            ]
-        );
+        $revisions = $this->_em->getRepository('BackBee\ClassContent\Revision')->findBy(['_content' => $content]);
+        foreach ($revisions as $revision) {
+            $this->_em->remove($revision);
+        }
 
         return $this;
     }

--- a/ClassContent/Tests/ClassContentPersistenceTest.php
+++ b/ClassContent/Tests/ClassContentPersistenceTest.php
@@ -123,6 +123,7 @@ class ClassContentPersistenceTest extends BackBeeTestCase
 
         $repository->deleteContent($content);
         self::$em->flush();
+        self::$em->clear();
 
         $this->assertNull($repository->find($uid));
     }


### PR DESCRIPTION
Updated `ClassContentManager` and `ClassContentRepository::deleteContent()` to fix revision deletion on revert action. This PR aims to fix the issue [backbee/backbee-standard #594](https://github.com/backbee/backbee-standard/issues/594).