### PR TITLE
Fix accept parameters creation for contentset

### DIFF
--- a/ClassContent/ContentSet.php
+++ b/ClassContent/ContentSet.php
@@ -654,7 +654,10 @@ class ContentSet extends AbstractClassContent implements \Iterator, \Countable
 
         if ('accept' === $var) {
             if (null !== $options) {
-                $this->_addAcceptedType(array_merge((array) $options, $this->getParamValue('accept')));
+
+                $accept = array_key_exists('value', $options) ? $options['value'] : $options;
+
+                $this->_addAcceptedType(array_merge((array) $accept, $this->getParamValue('accept')));
             }
         }
 


### PR DESCRIPTION
For accept parameters, we have two ways:

````
accept: ['MyContent', 'MyContent2']     =>   $options  

accept:      => $options['value']
    type: ContentTypeSelector
    value: ['MyContent', 'MyContent2']
````