### PR TITLE
[Security] updated its services to remove duplicated role voter

### DIFF
--- a/Config/services/security.yml
+++ b/Config/services/security.yml
@@ -82,7 +82,7 @@ services:
     security.access.decision_manager:
         class: BackBee\Security\Access\DecisionManager
         arguments:
-            - [@security.voter.sudo, @security.voter.bb_role, @security.voter.role, @security.voter.authenticated, @security.voter.bb_acl]
+            - [@security.voter.sudo, @security.voter.bb_role, @security.voter.authenticated, @security.voter.bb_acl]
             - affirmative
             - false
             - true


### PR DESCRIPTION
Removed duplicated `@security.voter.bb_role` in `security.access.decision_manager` service declaration.