### PR TITLE
[Bundle] updated BundleLoader::buildBundleDefinition() to also call ::started()

### DIFF
--- a/Bundle/BundleLoader.php
+++ b/Bundle/BundleLoader.php
@@ -370,6 +370,7 @@ class BundleLoader implements DumpableServiceInterface, DumpableServiceProxyInte
         $definition = new Definition($classname, array(new Reference('bbapp'), $bundleId, $baseDir));
         $definition->addTag('bundle', array('dispatch_event' => false));
         $definition->addMethodCall('start');
+        $definition->addMethodCall('started');
 
         return $definition;
     }


### PR DESCRIPTION
The first time a bundle is getting from the container, the method `::start()` is called. This is the expected behavior but we also have to invoke `::started()` method otherwise `::isStarted()` will always return `false`.

ping @crouillon 