### PR TITLE
[Controller] updated FrontController to return response if exists after dispatch of  event

### DIFF
--- a/Controller/FrontController.php
+++ b/Controller/FrontController.php
@@ -201,6 +201,10 @@ class FrontController implements HttpKernelInterface
         $event = new GetResponseEvent($this, $this->getRequest(), $type);
         $this->application->getEventDispatcher()->dispatch(KernelEvents::REQUEST, $event);
 
+        if (null !== $response = $event->getResponse()) {
+            return $response;
+        }
+
         try {
             if (null !== $request) {
                 $this->request = $request;


### PR DESCRIPTION
Currently, even if the dispatch of `kernel.request` event find a response, we don't take it in account and we keep running like it does not happen.

ping @crouillon 