### PR TITLE
MetaDataResolver : make resolveConst() method protected to allow proper overload by bundles

### DIFF
--- a/MetaData/MetaDataResolver.php
+++ b/MetaData/MetaDataResolver.php
@@ -271,7 +271,7 @@ class MetaDataResolver implements MetaDataResolverInterface
      *
      * @return string
      */
-    private function resolveConst($const, Page $page = null)
+    protected function resolveConst($const, Page $page = null)
     {
         $value = '';
         switch (strtolower($const)) {


### PR DESCRIPTION
Hello,

I need the resolveConst() to be protected, to allow tht addition of other "constants" by a bundle override.

thx