### PR TITLE
[Config] fixed Configurator::doBundleConfigExtend() to apply registry override only if save_in_registry exists and equals to true

### DIFF
--- a/Config/Configurator.php
+++ b/Config/Configurator.php
@@ -223,13 +223,17 @@ class Configurator
         $configConfig = $this->application->getConfig()->getConfigConfig();
         if (
             null === $configConfig
-            || array_key_exists('save_in_registry', $configConfig)
-            || true === $configConfig['save_in_registry']
+            || (
+                array_key_exists('save_in_registry', $configConfig)
+                && true === $configConfig['save_in_registry']
+            )
         ) {
-            $this->overrideConfigByRegistry($config, $options['bundle_id'], false, false) // First without context and environment
-                ->overrideConfigByRegistry($config, $options['bundle_id'], false, true)   // Second, only with environment
-                ->overrideConfigByRegistry($config, $options['bundle_id'], true, false)   // Third, only with context
-                ->overrideConfigByRegistry($config, $options['bundle_id'], true, true);   // Then, with both context and environment
+            $this
+                ->overrideConfigByRegistry($config, $options['bundle_id'], false, false) // First without context and environment
+                ->overrideConfigByRegistry($config, $options['bundle_id'], false, true)  // Second, only with environment
+                ->overrideConfigByRegistry($config, $options['bundle_id'], true, false)  // Third, only with context
+                ->overrideConfigByRegistry($config, $options['bundle_id'], true, true)   // Then, with both context and environment
+            ;
         }
     }
 


### PR DESCRIPTION
The if condition in `Configurator::doBundleConfigExtend()` to determine if we should apply registry override or not is wrong. Currently even if `save_in_registry` is equal to `false` Configurator still run the override by registry process. This PR aims to fix it.