### PR TITLE
[Util] updated the way EntityManagerCreator sets Doctrine metadata cache

### DIFF
--- a/Util/Doctrine/EntityManagerCreator.php
+++ b/Util/Doctrine/EntityManagerCreator.php
@@ -150,9 +150,19 @@ class EntityManagerCreator
                         'service' === $options['orm']['metadata_cache_driver']['type']
                         && isset($options['orm']['metadata_cache_driver']['id'])
                     ) {
-                        $serviceId = str_replace('@', '', $options['orm']['metadata_cache_driver']['id']);
-                        if (null !== $container && $container->has($serviceId)) {
-                            $config->setMetadataCacheImpl($container->get($serviceId));
+                        $service = null;
+                        $serviceId = $options['orm']['metadata_cache_driver']['id'];
+                        if (is_object($serviceId)) {
+                            $service = $serviceId;
+                        } elseif (is_string($serviceId)) {
+                            $serviceId = str_replace('@', '', $serviceId);
+                            if (null !== $container && $container->has($serviceId)) {
+                                $service = $container->get($serviceId);
+                            }
+                        }
+
+                        if (null !== $service) {
+                            $config->setMetadataCacheImpl($service);
                         }
                     }
                 }


### PR DESCRIPTION
Updated the way `EntityManagerCreator` sets Doctrine metadata cache according to provided configuration. In some case the service identifier is replaced by the object on `Config` compilation. To prevent the fatal error due to it, I added additionnal checks to do the right thing on string and on object.

ping @crouillon 