### PR TITLE
Introduce Rest\RevisionController + Add ClassContentManager::revertToRevision() feature

### DIFF
--- a/Config/route.yml
+++ b/Config/route.yml
@@ -544,6 +544,17 @@ bb.rest.classcontent.put_draft:
         type: "[a-zA-Z_\/]+"
         _method: PUT
 
+bb.rest.classcontent.patch_draft:
+    pattern: /rest/{version}/classcontent-draft/{type}/{uid}
+    defaults:
+        _action: patchDraftAction
+        _controller: BackBee\Rest\Controller\ClassContentController
+    requirements:
+        version: \d+
+        uid: \w{32}
+        type: "[a-zA-Z_\/]+"
+        _method: PATCH
+
 bb.rest.classcontent.put_draft_collection:
     pattern: /rest/{version}/classcontent-draft
     defaults:
@@ -739,6 +750,27 @@ bb.rest.keyword.patch:
     requirements:
         version: \d+
         _method: PATCH
+
+# API Rest Revision
+bb.rest.revision.get:
+    pattern: /rest/{version}/revision/{uid}
+    defaults:
+        _action: getAction
+        _controller: BackBee\Rest\Controller\RevisionController
+    requirements:
+        version: \d+
+        _method: GET
+
+bb.rest.revision.get_collection_by_content:
+  pattern: /rest/{version}/revision/{type}/{uid}
+  defaults:
+    _action: getCollectionByContentAction
+    _controller: BackBee\Rest\Controller\RevisionController
+  requirements:
+    version: \d+
+    uid: \w{32}
+    type: "[a-zA-Z_\/]+"
+    _method: GET
 
 # BackBee rss
 bb.rss:

--- a/Rest/Controller/RevisionController.php
+++ b/Rest/Controller/RevisionController.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Rest\Controller;
+
+use BackBee\ClassContent\Exception\InvalidContentTypeException;
+use BackBee\ClassContent\Revision;
+use BackBee\Rest\Controller\Annotations as Rest;
+
+use Doctrine\ORM\Tools\Pagination\Paginator;
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Revision API Controller.
+ *
+ * @category    BackBee
+ *
+ * @copyright   Lp digital system
+ * @author      c.rouillon <charles.rouillon@lp-digital.fr>
+ */
+class RevisionController extends AbstractRestController
+{
+
+    /**
+     * Returns a revision.
+     *
+     * @return Symfony\Component\HttpFoundation\JsonResponse
+     *
+     * @Rest\ParamConverter(name="revision", class="BackBee\ClassContent\Revision")
+     * @Rest\Security("is_fully_authenticated() & has_role('ROLE_API_USER')")
+     */
+    public function getAction(Revision $revision)
+    {
+        $this->granted('VIEW', $revision->getContent());
+
+        $response = $this->createJsonResponse();
+        $response->setData($revision->jsonSerialize(Revision::JSON_REVISION_FORMAT));
+
+        return $response;
+    }
+
+    /**
+     * Returns collection of revisions for a content.
+     *
+     * @return Symfony\Component\HttpFoundation\JsonResponse
+     *
+     * @Rest\Pagination(default_count=25, max_count=100)
+     * @Rest\Security("is_fully_authenticated() & has_role('ROLE_API_USER')")
+     */
+    public function getCollectionByContentAction($type, $uid, $start, $count)
+    {
+        $content = $this->findOneByTypeAndUid($type, $uid);
+        $this->granted('VIEW', $content);
+
+        $revisions = $this->getEntityManager()
+                ->getRepository('BackBee\ClassContent\Revision')
+                ->getRevisions($content, [Revision::STATE_COMMITTED], $start, $count);
+
+        $result = [];
+        foreach ($revisions as $revision) {
+            $result[] = $revision->jsonSerialize(Revision::JSON_REVISION_FORMAT);
+        }
+
+        $response = $this->createJsonResponse();
+        $response->setData($result);
+
+        if ($revisions instanceof Paginator) {
+            $response->headers->set('Content-Range', sprintf('%d-%d/%d', $start, $start +
+                            count($result) - 1, count($revisions)));
+        }
+
+        return $response;
+    }
+
+    /**
+     * Returns classcontent according to provided $type and $uid.
+     *
+     * @param  string               $type Either short or full namespace of a classcontent.
+     *                                    (full: BackBee\ClassContent\Block\paragraph => short: Block/paragraph)
+     * @param  string               $uid  A unique identifier of a content.
+     *
+     * @return AbstractClassContent       The matching content.
+     *
+     * @throws NotFoundHttpException      Thrown if no matching content found.
+     */
+    private function findOneByTypeAndUid($type, $uid)
+    {
+        try {
+            $content = $this->getApplication()
+                    ->getContainer()
+                    ->get('classcontent.manager')
+                    ->findOneByTypeAndUid($type, $uid, true);
+        } catch (InvalidContentTypeException $e) {
+            throw new NotFoundHttpException(sprintf('Provided content type (:%s) is invalid.', $type), $e);
+        }
+
+        if (null === $content) {
+            throw new NotFoundHttpException(sprintf('Cannot find `%s` with uid `%s`.', $type, $uid));
+        }
+
+        return $content;
+    }
+}


### PR DESCRIPTION
Introduce three new REST services:
 * `RevisionController::getAction()`: returns a specific revision by uid.
 * `RevisionController::getCollectionByContentAction()`: Returns collection of revisions for a content.
 * `ClassContentController::patchDraftAction()`: Reverts user's draft of a content to a specific revision number. Possible values for revision number are:
     *  negative value: revert to current revision decrease from value.
     *  empty value: revert to last committed revision.
     *  positive value: revert to specific revision if exists.