### PR TITLE
[Installer] fixed EntityFinder::getNamespace() to refer to ';' instead of '{'

### DIFF
--- a/Installer/EntityFinder.php
+++ b/Installer/EntityFinder.php
@@ -125,7 +125,7 @@ class EntityFinder
     {
         $src = file_get_contents($file);
         $offset = strpos($src, 'namespace');
-        $src = substr($src, 0, strpos($src, '{', $offset));
+        $src = substr($src, 0, strpos($src, ';', $offset)) . ';';
         $tokens = token_get_all($src);
         $count = count($tokens);
         $namespace = '';


### PR DESCRIPTION
Changed `EntityFinder::getNamespace()` to refer to the first occurence of `;` instead of `{` cause in some cases we broke comment block so `token_get_all()` generates PHP warnings.