### PR TITLE
[ClassContent] updated ClassContentQueryBuilder::addClassFilter 

### DIFF
--- a/ClassContent/Repository/ClassContentQueryBuilder.php
+++ b/ClassContent/Repository/ClassContentQueryBuilder.php
@@ -152,8 +152,10 @@ class ClassContentQueryBuilder extends QueryBuilder
         if (is_array($classes) && count($classes) !== 0) {
             $filters = array();
             foreach ($classes as $class) {
+                class_exists($class);
                 $filters[] = 'cc INSTANCE OF \''.  $class .'\'';
             }
+
             $filter = implode(' OR ', $filters);
 
             $this->andWhere($filter);


### PR DESCRIPTION
Updated `ClassContentQueryBuilder::addClassFilter` to ensure that requested classes are loaded cause sometimes we get error about classcontent that are not part of AbstractClassContent discriminators.

ping @crouillon 