### PR TITLE
[Config] Fix bundle configuration extend by file

### DIFF
--- a/Config/Configurator.php
+++ b/Config/Configurator.php
@@ -251,7 +251,7 @@ class Configurator
         );
 
         foreach ($directories as $directory) {
-            $config->extend($directory, true);
+            $config->extend($directory, false);
         }
     }
 


### PR DESCRIPTION
A project bundle configuration file (ie /repository/Config/bundle/.../config.yml) was overriding the initial config, requireing to repeat every unchanged initial values.
The fix allow to only store in the file the changed values