### PR TITLE
[ClassContent] improved FileJsonSerializeTrait::jsonSerialize()

### DIFF
--- a/ClassContent/Traits/Element/FileJsonSerializeTrait.php
+++ b/ClassContent/Traits/Element/FileJsonSerializeTrait.php
@@ -19,7 +19,10 @@ trait FileJsonSerializeTrait
         if (AbstractContent::JSON_DEFAULT_FORMAT === $format || AbstractContent::JSON_CONCISE_FORMAT === $format) {
             $data['extra']['file_size'] = null;
             if (null !== $stat = $this->getParamValue('stat')) {
-                $stat = json_decode($stat, true);
+                if (is_string($stat)) {
+                    $stat = json_decode($stat, true);
+                }
+
                 if (is_array($stat) && isset($stat['size'])) {
                     $data['extra']['file_size'] = $stat['size'];
                 }


### PR DESCRIPTION
Added more checks to `FileJsonSerializeTrait::jsonSerialize()` to prevent error like this:

`PHP Warning: json_decode() expects parameter 1 to be string, array given in vendor/backbee/backbee/ClassContent/Traits/Element/FileJsonSerializeTrait.php on line 22`