### PR TITLE
[BugFix] Correction of some Rest\Security annotations

### DIFF
--- a/Rest/Controller/GroupController.php
+++ b/Rest/Controller/GroupController.php
@@ -132,7 +132,7 @@ class GroupController extends AbstractRestController
      *  @Assert\NotBlank(message="Name is required"),
      *  @Assert\Length(max=50, minMessage="Maximum length of name is 50 characters")
      * })
-     * @Rest\Security("is_fully_authenticated() & has_role('ROLE_API_USER') & is_granted('CREATE', '\BackBee\Security\Group')")
+     * @Rest\Security("is_fully_authenticated() & has_role('ROLE_API_USER') & is_granted('CREATE', 'BackBee\\Security\\Group')")
      */
     public function postAction(Request $request)
     {

--- a/Rest/Controller/MediaFolderController.php
+++ b/Rest/Controller/MediaFolderController.php
@@ -58,7 +58,7 @@ class MediaFolderController extends AbstractRestController
      * @Rest\ParamConverter(
      *   name="parent", id_name="parent_uid", id_source="query", class="BackBee\NestedNode\MediaFolder", required=false
      * )
-     * @Rest\Security("is_fully_authenticated() & has_role('ROLE_API_USER') & is_granted('VIEW','\BackBee\NestedNode\MediaFolder')")
+     * @Rest\Security("is_fully_authenticated() & has_role('ROLE_API_USER') & is_granted('VIEW','BackBee\\NestedNode\\MediaFolder')")
      */
     public function getCollectionAction($start, MediaFolder $parent = null)
     {
@@ -148,7 +148,7 @@ class MediaFolderController extends AbstractRestController
      * @Rest\ParamConverter(
      *   name="parent", id_name="parent_uid", id_source="request", class="BackBee\NestedNode\MediaFolder", required=false
      * )
-     * @Rest\Security("is_fully_authenticated() & has_role('ROLE_API_USER') & is_granted('CREATE', '\BackBee\NestedNode\MediaFolder')")
+     * @Rest\Security("is_fully_authenticated() & has_role('ROLE_API_USER') & is_granted('CREATE', 'BackBee\\NestedNode\\MediaFolder')")
      */
     public function postAction(Request $request, $parent = null)
     {


### PR DESCRIPTION
As example, getting collections of BackBee\NestedNode\MediaFolder was never granted by ACL
