### PR TITLE
[Tree] fix pages levels for Section movements

### DIFF
--- a/NestedNode/Repository/PageRepository.php
+++ b/NestedNode/Repository/PageRepository.php
@@ -668,7 +668,7 @@ class PageRepository extends EntityRepository
      */
     private function moveSectionAsSiblingOf(Page $page, Page $target, $asPrevious = true)
     {
-        $delta = $page->getLevel() - $target->getLevel();
+        $delta = $target->getLevel() - $page->getLevel();
         $this->shiftLevel($page, $delta);
 
         $this->getEntityManager()


### PR DESCRIPTION
When a Section moves in tree (goes down in a parent and back to home), Pages levels was wrong.
This seams to fix the issue.

Test case
I have a Tree like this : 
- Category_1
    - Article_1
- Category_2
    - Article_2
- Category_3
    - Article_3

I move Category_3 to Category_2 - OK
I move Category_3 to back to Home - FAIL (Category_3 is not visible on tree. Pages and sub-pages keeps old levels in database.)

Thanks a lot.