### PR TITLE
[Bundle] updated BundleLoader::loadFullBundles() to load every bundle services first

### DIFF
--- a/Bundle/BundleLoader.php
+++ b/Bundle/BundleLoader.php
@@ -380,6 +380,7 @@ class BundleLoader implements DumpableServiceInterface, DumpableServiceProxyInte
      */
     private function loadFullBundles()
     {
+        $data = [];
         foreach ($this->bundlesBaseDir as $serviceId => $baseDir) {
             $config = $this->loadAndGetBundleConfigByBaseDir($serviceId, $baseDir);
             $bundleConfig = $config->getSection('bundle');
@@ -389,7 +390,14 @@ class BundleLoader implements DumpableServiceInterface, DumpableServiceProxyInte
 
             $recipes = $this->getLoaderRecipesByConfig($config);
 
+            $data[] = [$config, $recipes];
+
             $this->loadServices($config, $this->getCallbackFromRecipes(self::SERVICE_RECIPE_KEY, $recipes));
+        }
+
+        foreach ($data as $row) {
+            list($config, $recipes) = $row;
+
             $this->loadEvents($config, $this->getCallbackFromRecipes(self::EVENT_RECIPE_KEY, $recipes));
             $this->loadRoutes($config, $this->getCallbackFromRecipes(self::ROUTE_RECIPE_KEY, $recipes));
             $this->addClassContentDir($config, $this->getCallbackFromRecipes(self::CLASSCONTENT_RECIPE_KEY, $recipes));


### PR DESCRIPTION
Updated `BundleLoader::loadFullBundles()` to load every bundle's services first. Actually, we load every bundle completely one by one so `::loadRoutes()` is invoked too early. It means that only the first declared bundle can override `routing` service definition. Which is not what we want. This PR aims to fix it.